### PR TITLE
Add flags for existing switches

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -75,3 +75,24 @@ These are also available on the `chrome://flags` page.
   `ClearDataOnExit` | Clears all browsing data on exit.
   `DisableLinkDrag` | Prevents dragging of links and selected text. Allows selecting text from a middle of a link. Also allows starting selection without first clearing the existing one. This behaviour is similar to the one from older Opera. See https://github.com/ungoogled-software/ungoogled-chromium/pull/2080 and https://github.com/ungoogled-software/ungoogled-chromium/discussions/2055 for more information.
   `DisableQRGenerator` | Disables the QR generator for sharing page links.
+
+
+## Flags for existing switches
+
+Chromium contains switches that do no have corresponding entries in `chrome://flags`. For convenience, ungoogled-chromium has created entries for some of the commonly-used switches.
+
+- ### Available on all platforms
+  <code>Switch&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
+  -- | --
+  `--disable-top-sites` | Disables the top sites and most visited entries on the new tab page.
+  `--disable-webgl` | Disable all versions of WebGL.
+  `--enable-low-end-device-mode` | Force low-end device mode when set.
+  `--force-dark-mode` | Forces dark mode in UI for platforms that support it.
+  `--no-pings` | Don't send hyperlink auditing pings.
+  `--web-ui-dark-mode` | Whether to enable 'dark mode' enhancements for UIs implemented with web technologies.
+  `--webrtc-ip-handling-policy` | Restrict which IP addresses and interfaces WebRTC uses.
+- ### Available only on desktop
+  <code>Switch&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
+  -- | --
+  `--incognito` | Start in Incognito.
+  `--start-maximized` | Starts the browser maximized, regardless of any previous settings.

--- a/patches/extra/ungoogled-chromium/add-flags-for-existing-switches.patch
+++ b/patches/extra/ungoogled-chromium/add-flags-for-existing-switches.patch
@@ -1,0 +1,85 @@
+--- a/chrome/browser/about_flags.cc
++++ b/chrome/browser/about_flags.cc
+@@ -3571,10 +3571,12 @@ const FeatureEntry::FeatureVariation kVc
+ #include "chrome/browser/ungoogled_flag_choices.h"
+ #include "chrome/browser/bromite_flag_choices.h"
+ #include "chrome/browser/ungoogled_platform_flag_choices.h"
++#include "chrome/browser/existing_switch_flag_choices.h"
+ const FeatureEntry kFeatureEntries[] = {
+ #include "chrome/browser/ungoogled_flag_entries.h"
+ #include "chrome/browser/bromite_flag_entries.h"
+ #include "chrome/browser/ungoogled_platform_flag_entries.h"
++#include "chrome/browser/existing_switch_flag_entries.h"
+ // Include generated flags for flag unexpiry; see //docs/flag_expiry.md and
+ // //tools/flags/generate_unexpire_flags.py.
+ #include "build/chromeos_buildflags.h"
+--- /dev/null
++++ b/chrome/browser/existing_switch_flag_choices.h
+@@ -0,0 +1,21 @@
++// Copyright (c) 2023 The ungoogled-chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_EXISTING_SWITCH_FLAG_CHOICES_H_
++#define CHROME_BROWSER_EXISTING_SWITCH_FLAG_CHOICES_H_
++const FeatureEntry::Choice kWebRTCIPPolicy[] = {
++    {"Disable non proxied udp",
++     "webrtc-ip-handling-policy",
++     "disable_non_proxied_udp"},
++    {"Default",
++     "webrtc-ip-handling-policy",
++     "default"},
++    {"Default public and private interfaces",
++     "webrtc-ip-handling-policy",
++     "default_public_and_private_interfaces"},
++    {"Default public interface only",
++     "webrtc-ip-handling-policy",
++     "default_public_interface_only"},
++};
++#endif  // CHROME_BROWSER_EXISTING_SWITCH_FLAG_CHOICES_H_
+--- /dev/null
++++ b/chrome/browser/existing_switch_flag_entries.h
+@@ -0,0 +1,43 @@
++// Copyright (c) 2023 The ungoogled-chromium Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_EXISTING_SWITCH_FLAG_ENTRIES_H_
++#define CHROME_BROWSER_EXISTING_SWITCH_FLAG_ENTRIES_H_
++    {"disable-top-sites",
++     "Disable Top Sites",
++     "Disables the top sites and most visited entries on the new tab page. Chromium feature, ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("disable-top-sites")},
++    {"disable-webgl",
++     "Disable WebGL",
++     "Disable all versions of WebGL. Chromium feature, ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("disable-webgl")},
++    {"enable-low-end-device-mode",
++     "Enable low-end device mode",
++     "Force low-end device mode when set. Chromium feature, ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("enable-low-end-device-mode")},
++    {"force-dark-mode",
++     "Force Dark Mode",
++     "Forces dark mode in UI for platforms that support it. Chromium feature, ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("force-dark-mode")},
++    {"incognito",
++     "Start in incognito",
++     "Start in Incognito. Chromium feature, ungoogled-chromium flag.",
++     kOsDesktop, SINGLE_VALUE_TYPE("incognito")},
++    {"no-pings",
++     "No Pings",
++     "Don't send hyperlink auditing pings. Chromium feature, ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("no-pings")},
++    {"start-maximized",
++     "Start Maximized",
++     "Starts the browser maximized, regardless of any previous settings. Chromium feature, ungoogled-chromium flag.",
++     kOsDesktop, SINGLE_VALUE_TYPE("start-maximized")},
++    {"web-ui-dark-mode",
++     "Web UI Dark Mode",
++     "Whether to enable 'dark mode' enhancements for UIs implemented with web technologies. Chromium feature, ungoogled-chromium flag.",
++     kOsAll, FEATURE_VALUE_TYPE(features::kWebUIDarkMode)},
++    {"webrtc-ip-handling-policy",
++     "WebRTC IP policy",
++     "Restrict which IP addresses and interfaces WebRTC uses. Chromium feature, ungoogled-chromium flag.",
++     kOsAll, MULTI_VALUE_TYPE(kWebRTCIPPolicy)},
++#endif  // CHROME_BROWSER_EXISTING_SWITCH_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -102,3 +102,4 @@ extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
 extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
 extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
 extra/ungoogled-chromium/default-webrtc-ip-handling-policy.patch
+extra/ungoogled-chromium/add-flags-for-existing-switches.patch


### PR DESCRIPTION
This PR creates `chrome://flags` entries for existing Chromium switches and features.  
There have been many previous requests for flags that already exist, albeit only as command-line switches.  The most prominent ones are for starting in incognito and removing the tiles on the new tab page.  This also helps in situations where adding switches would be difficult, such as on mobile.  

The initial entries:  
* Disable Top Sites:  Removes the top sites and most visited tiles on the new tab page.
* Disable WebGL:  Disable all versions of WebGL.
* Force Dark Mode:  Forces dark mode in UI for platforms that support it.
* Incognito:  Starts the browser in incognito.  
* No Pings:  Disables ping attribute functionalty on \<a\> tags which can be a privacy concern.  
* Start Maximized:  Always starts the browser maximized.  
* Web UI Dark Mode:  Forces dark mode for internal chrome pages.  

This isn't meant to be an exhaustive list, but I'd like to add the more commonly used/requested ones.  
I'll keep this as a draft for a while so everyone has time to add suggestions for other useful entries.  