### PR TITLE
Add patch that allows themes in Incognito windows

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -36,6 +36,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed. Only takes the value `never`.
   `--custom-ntp` | Allows setting a custom URL for the new tab page. Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`). This applies for incognito windows as well when not set to a `chrome://` internal page.
   `--disable-sharing-hub` | Disables the sharing hub button.
+  `--enable-incognito-themes` | Allows themes to change the appearance of Incognito windows.
   `--hide-extensions-menu` | Hides the extensions menu (the puzzle piece icon).
   `--hide-fullscreen-exit-ui` | Hides the "X" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode.
   `--hide-sidepanel-button` | Hides the SidePanel Button.

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -15,11 +15,11 @@
 
  #include "chrome/browser/themes/theme_service.h"
 
-+#include "base/command_line.h"
++#include "base/command_line.h
  #include "base/feature_list.h"
  #include "base/no_destructor.h"
  #include "build/build_config.h"
-@@ -145,6 +146,31 @@ SeparatorColorCache& GetSeparatorColorCache() {
+@@ -171,6 +172,32 @@ SeparatorColorCache& GetSeparatorColorCache() {
    return *cache;
  }
 
@@ -48,10 +48,11 @@
 +  }
 +}
 +
++
  }  // namespace
 
  const char ThemeHelper::kDefaultThemeID[] = "";
-@@ -255,9 +281,11 @@ SkColor ThemeHelper::GetColor(int id,
+@@ -281,9 +308,11 @@ SkColor ThemeHelper::GetColor(int id,
                                const CustomThemeSupplier* theme_supplier) const {
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
@@ -65,7 +66,7 @@
        return color;
    }
 
-@@ -273,7 +301,8 @@ color_utils::HSL ThemeHelper::GetTint(
+@@ -299,7 +328,8 @@ color_utils::HSL ThemeHelper::GetTint(
    if (theme_supplier && theme_supplier->GetTint(id, &hsl))
      return hsl;
 
@@ -75,7 +76,7 @@
  }
 
  gfx::ImageSkia* ThemeHelper::GetImageSkiaNamed(
-@@ -478,7 +507,18 @@ SkColor ThemeHelper::GetDefaultColor(
+@@ -554,7 +584,18 @@ SkColor ThemeHelper::GetDefaultColor(
                        incognito, theme_supplier);
    }
 
@@ -95,8 +96,8 @@
  }
 
  // static
-@@ -503,6 +543,20 @@ bool ThemeHelper::UseDarkModeColors(const CustomThemeSupplier* theme_supplier) {
-   return native_theme->ShouldUseDarkColors();
+@@ -565,6 +606,20 @@ bool ThemeHelper::UseDarkModeColors(const CustomThemeSupplier* theme_supplier) {
+          ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors();
  }
 
 +// static
@@ -118,7 +119,7 @@
      bool incognito,
 --- a/chrome/browser/themes/theme_service.cc
 +++ b/chrome/browser/themes/theme_service.cc
-@@ -485,7 +485,7 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
+@@ -507,7 +507,7 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
      if (auto provider_color_id = ThemeProviderColorIdToColorId(id)) {
        const ui::NativeTheme* native_theme = nullptr;
 
@@ -127,7 +128,7 @@
          native_theme = ui::NativeTheme::GetInstanceForDarkUI();
        } else {
          native_theme = ui::NativeTheme::GetInstanceForNativeUi();
-@@ -512,7 +512,8 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
+@@ -532,7 +532,8 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
 
  CustomThemeSupplier* ThemeService::BrowserThemeProvider::GetThemeSupplier()
      const {
@@ -137,7 +138,7 @@
  }
 
  // ThemeService ---------------------------------------------------------------
-@@ -752,7 +753,9 @@ ThemeSyncableService* ThemeService::GetThemeSyncableService() const {
+@@ -772,7 +773,9 @@ ThemeSyncableService* ThemeService::GetThemeSyncableService() const {
  const ui::ThemeProvider& ThemeService::GetThemeProviderForProfile(
      Profile* profile) {
    ThemeService* service = ThemeServiceFactory::GetForProfile(profile);
@@ -150,7 +151,7 @@
 
 --- a/chrome/browser/ui/views/frame/browser_frame.cc
 +++ b/chrome/browser/ui/views/frame/browser_frame.cc
-@@ -257,8 +257,10 @@ ui::ColorProviderManager::ThemeInitializerSupplier*
+@@ -248,8 +248,10 @@ ui::ColorProviderManager::ThemeInitializerSupplier*
  BrowserFrame::GetCustomTheme() const {
    Browser* browser = browser_view_->browser();
    // If this is an incognito profile, there should never be a custom theme.
@@ -162,7 +163,7 @@
    auto* app_controller = browser->app_controller();
    // Ignore GTK+ for web apps with window-controls-overlay as the
    // display_override so the web contents can blend with the overlay by using
-@@ -391,7 +393,8 @@ void BrowserFrame::SelectNativeTheme() {
+@@ -382,7 +384,8 @@ void BrowserFrame::SelectNativeTheme() {
    // Select between regular, dark and GTK theme.
    ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
 
@@ -182,7 +183,7 @@
  #include "base/containers/adapters.h"
  #include "base/i18n/rtl.h"
  #include "base/notreached.h"
-@@ -1816,7 +1817,7 @@ const ui::NativeTheme* Widget::GetNativeTheme() const {
+@@ -1818,7 +1819,7 @@ const ui::NativeTheme* Widget::GetNativeTheme() const {
    if (native_theme_)
      return native_theme_;
 

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -1,9 +1,9 @@
 --- a/chrome/browser/ungoogled_flag_entries.h
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -112,4 +112,8 @@
-     "Hide Extensions Menu",
-     "Hides the extensions menu (the puzzle piece icon) that allows the user to control extensions site access.  ungoogled-chromium flag.",
-     kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
+      "Hide Extensions Menu",
+      "Hides the extensions menu (the puzzle piece icon) that allows the user to control extensions site access.  ungoogled-chromium flag.",
+      kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
 +    {"enable-incognito-themes",
 +     "Enable themes in Incognito mode",
 +     "Allows themes to override Google's built-in Incognito theming.  ungoogled-chromium flag.",

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -117,6 +117,30 @@
  gfx::Image ThemeHelper::GetImageNamed(
      int id,
      bool incognito,
+     --- a/chrome/browser/themes/theme-helper.h
++++ b/chrome/browser/themes/theme-helper.h
+@@ -110,9 +110,21 @@ class ThemeHelper {
+  private:
+   friend class theme_service_internal::ThemeServiceTest;
+
++  // Whether the default incognito color/tint for |id| should be used, if
++  // available.
++  static bool UseIncognitoColor(int id,
++                                const CustomThemeSupplier* theme_supplier);
++
+   // Whether dark default colors/tints should be used, if available.
+   static bool UseDarkModeColors(const CustomThemeSupplier* theme_supplier);
+
++  // Whether the color from |theme_supplier| (if any) should be ignored for
++  // the given |id| and |incognito| state.
++  static bool ShouldIgnoreThemeSupplier(
++      int id,
++      bool incognito,
++      const CustomThemeSupplier* theme_supplier);
++
+   // Returns a cross platform image for an id.
+   gfx::Image GetImageNamed(int id,
+                            bool incognito,
 --- a/chrome/browser/themes/theme_service.cc
 +++ b/chrome/browser/themes/theme_service.cc
 @@ -507,7 +507,7 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -19,7 +19,7 @@
  #include "base/feature_list.h"
  #include "base/no_destructor.h"
  #include "build/build_config.h"
-@@ -140,6 +141,31 @@ SeparatorColorCache& GetSeparatorColorCache() {
+@@ -145,6 +146,31 @@ SeparatorColorCache& GetSeparatorColorCache() {
    return *cache;
  }
 
@@ -51,20 +51,21 @@
  }  // namespace
 
  const char ThemeHelper::kDefaultThemeID[] = "";
-@@ -258,9 +284,10 @@ SkColor ThemeHelper::GetColor(int id,
-   if (omnibox_color.has_value())
-     return omnibox_color.value();
+@@ -255,9 +281,11 @@ SkColor ThemeHelper::GetColor(int id,
+                               const CustomThemeSupplier* theme_supplier) const {
+   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
 -  if (theme_supplier && !incognito) {
-+  if (theme_supplier && !ShouldIgnoreThemeSupplier(id, incognito, theme_supplier)) {
++  if (theme_supplier &&
++        !ShouldIgnoreThemeSupplier(id, incognito, theme_supplier)) {
      SkColor color;
--    if (theme_supplier->GetColor(id, &color)) {
+-    if (theme_supplier->GetColor(id, &color))
 +    const int theme_supplier_id = incognito ? GetIncognitoId(id) : id;
-+    if (theme_supplier->GetColor(theme_supplier_id, &color)) {
-       if (has_custom_color)
-         *has_custom_color = true;
++    if (theme_supplier->GetColor(theme_supplier_id, &color))
        return color;
-@@ -279,7 +306,8 @@ color_utils::HSL ThemeHelper::GetTint(
+   }
+
+@@ -273,7 +301,8 @@ color_utils::HSL ThemeHelper::GetTint(
    if (theme_supplier && theme_supplier->GetTint(id, &hsl))
      return hsl;
 
@@ -74,21 +75,16 @@
  }
 
  gfx::ImageSkia* ThemeHelper::GetImageSkiaNamed(
-@@ -454,7 +482,8 @@ SkColor ThemeHelper::GetDefaultColor(
-     }
+@@ -478,7 +507,18 @@ SkColor ThemeHelper::GetDefaultColor(
+                       incognito, theme_supplier);
    }
 
 -  return TP::GetDefaultColor(id, incognito, UseDarkModeColors(theme_supplier));
 +  const bool use_incognito_color = incognito && UseIncognitoColor(id, theme_supplier);
 +  return TP::GetDefaultColor(id, use_incognito_color, UseDarkModeColors(theme_supplier));
- }
-
- // static
-@@ -739,3 +768,26 @@ SkColor ThemeHelper::GetTabGroupColor(
-   }
-   return GetTabGroupColors(id)[incognito || use_dark_mode_colors];
- }
++}
 +
++// static
 +bool ThemeHelper::UseIncognitoColor(int id,
 +                                    const CustomThemeSupplier* theme_supplier) {
 +  // Incognito is disabled for any non-ignored custom theme colors so they apply
@@ -96,14 +92,19 @@
 +  return ShouldIgnoreThemeSupplier(id, true, theme_supplier) ||
 +         (!IsCustomTheme(theme_supplier) &&
 +          (!theme_supplier || theme_supplier->CanUseIncognitoColors()));
-+}
+ }
+
+ // static
+@@ -503,6 +543,20 @@ bool ThemeHelper::UseDarkModeColors(const CustomThemeSupplier* theme_supplier) {
+   return native_theme->ShouldUseDarkColors();
+ }
+
 +// static
 +bool ThemeHelper::ShouldIgnoreThemeSupplier(
 +    int id,
 +    bool incognito,
 +    const CustomThemeSupplier* theme_supplier) {
-+  if (incognito &&
-+        !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
++  if (incognito && !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
 +    return true;
 +  }
 +  // The incognito NTP uses the default background color instead of any theme
@@ -111,42 +112,77 @@
 +  return incognito && (id == TP::COLOR_NTP_BACKGROUND) &&
 +         !HasCustomImage(IDR_THEME_NTP_BACKGROUND, theme_supplier);
 +}
++
+ gfx::Image ThemeHelper::GetImageNamed(
+     int id,
+     bool incognito,
 --- a/chrome/browser/themes/theme_service.cc
 +++ b/chrome/browser/themes/theme_service.cc
-@@ -314,7 +314,9 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
+@@ -485,7 +485,7 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
+     if (auto provider_color_id = ThemeProviderColorIdToColorId(id)) {
+       const ui::NativeTheme* native_theme = nullptr;
+
+-      if (incognito_) {
++      if (incognito_ && !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
+         native_theme = ui::NativeTheme::GetInstanceForDarkUI();
+       } else {
+         native_theme = ui::NativeTheme::GetInstanceForNativeUi();
+@@ -512,7 +512,8 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
 
  CustomThemeSupplier* ThemeService::BrowserThemeProvider::GetThemeSupplier()
      const {
 -  return incognito_ ? nullptr : delegate_->GetThemeSupplier();
-+      bool should_ignore_theme_supplier =
-+        incognito_ && !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes");
-+  return should_ignore_theme_supplier ? nullptr : delegate_->GetThemeSupplier();
++      const bool ignore_theme_supplier = incognito_ && !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes");
++  return ignore_theme_supplier ? nullptr : delegate_->GetThemeSupplier();
  }
 
  // ThemeService ---------------------------------------------------------------
+@@ -752,7 +753,9 @@ ThemeSyncableService* ThemeService::GetThemeSyncableService() const {
+ const ui::ThemeProvider& ThemeService::GetThemeProviderForProfile(
+     Profile* profile) {
+   ThemeService* service = ThemeServiceFactory::GetForProfile(profile);
+-  return profile->IsIncognitoProfile() ? service->incognito_theme_provider_
++  const bool use_incognito_provider = profile->IsIncognitoProfile() &&
++      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes");
++  return use_incognito_provider ? service->incognito_theme_provider_
+                                        : service->original_theme_provider_;
+ }
+
 --- a/chrome/browser/ui/views/frame/browser_frame.cc
 +++ b/chrome/browser/ui/views/frame/browser_frame.cc
-@@ -369,7 +369,8 @@ void BrowserFrame::SelectNativeTheme() {
+@@ -257,8 +257,10 @@ ui::ColorProviderManager::ThemeInitializerSupplier*
+ BrowserFrame::GetCustomTheme() const {
+   Browser* browser = browser_view_->browser();
+   // If this is an incognito profile, there should never be a custom theme.
+-  if (browser->profile()->IsIncognitoProfile())
++  if (browser->profile()->IsIncognitoProfile() &&
++      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
+     return nullptr;
++  }
+   auto* app_controller = browser->app_controller();
+   // Ignore GTK+ for web apps with window-controls-overlay as the
+   // display_override so the web contents can blend with the overlay by using
+@@ -391,7 +393,8 @@ void BrowserFrame::SelectNativeTheme() {
    // Select between regular, dark and GTK theme.
    ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
 
 -  if (browser_view_->browser()->profile()->IsIncognitoProfile()) {
 +  if (browser_view_->browser()->profile()->IsIncognitoProfile() &&
-+      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
++        !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
      // No matter if we are using the default theme or not we always use the dark
      // ui instance.
      SetNativeTheme(ui::NativeTheme::GetInstanceForDarkUI());
 --- a/ui/views/widget/widget.cc
 +++ b/ui/views/widget/widget.cc
-@@ -9,6 +9,7 @@
-
+@@ -10,6 +10,7 @@
  #include "base/auto_reset.h"
  #include "base/bind.h"
-+#include "base/command_line.h"
  #include "base/check_op.h"
++#include "base/command_line.h"
  #include "base/containers/adapters.h"
  #include "base/i18n/rtl.h"
-@@ -1784,7 +1785,7 @@ const ui::NativeTheme* Widget::GetNativeTheme() const {
+ #include "base/notreached.h"
+@@ -1816,7 +1817,7 @@ const ui::NativeTheme* Widget::GetNativeTheme() const {
    if (native_theme_)
      return native_theme_;
 

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -1,0 +1,165 @@
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -100,4 +100,8 @@
+      "Custom HTTP Accept Header",
+      "Set a custom value for the Accept header which is sent by the browser with every HTTP request.  (e.g. `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`).  ungoogled-chromium flag.",
+      kOsAll, ORIGIN_LIST_VALUE_TYPE("http-accept-header", "")},
++    {"enable-incognito-themes",
++     "Enable themes in Incognito mode",
++     "Allows themes to override Google's built-in Incognito theming.  ungoogled-chromium flag.",
++     kOsAll, SINGLE_VALUE_TYPE("enable-incognito-themes")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+--- a/chrome/browser/themes/theme_helper.cc
++++ b/chrome/browser/themes/theme_helper.cc
+@@ -4,6 +4,7 @@
+
+ #include "chrome/browser/themes/theme_service.h"
+
++#include "base/command_line.h"
+ #include "base/feature_list.h"
+ #include "base/no_destructor.h"
+ #include "build/build_config.h"
+@@ -140,6 +141,31 @@ SeparatorColorCache& GetSeparatorColorCache() {
+   return *cache;
+ }
+
++// For legacy reasons, the theme supplier requires the incognito variants of
++// color IDs.  This converts from normal to incognito IDs where they exist.
++int GetIncognitoId(int id) {
++  switch (id) {
++    case TP::COLOR_FRAME_ACTIVE:
++      return TP::COLOR_FRAME_ACTIVE_INCOGNITO;
++    case TP::COLOR_FRAME_INACTIVE:
++      return TP::COLOR_FRAME_INACTIVE_INCOGNITO;
++    case TP::COLOR_TAB_BACKGROUND_INACTIVE_FRAME_ACTIVE:
++      return TP::COLOR_TAB_BACKGROUND_INACTIVE_FRAME_ACTIVE_INCOGNITO;
++    case TP::COLOR_TAB_BACKGROUND_INACTIVE_FRAME_INACTIVE:
++      return TP::COLOR_TAB_BACKGROUND_INACTIVE_FRAME_INACTIVE_INCOGNITO;
++    case TP::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE:
++      return TP::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE_INCOGNITO;
++    case TP::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_INACTIVE:
++      return TP::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_INACTIVE_INCOGNITO;
++    case TP::COLOR_WINDOW_CONTROL_BUTTON_BACKGROUND_ACTIVE:
++      return TP::COLOR_WINDOW_CONTROL_BUTTON_BACKGROUND_INCOGNITO_ACTIVE;
++    case TP::COLOR_WINDOW_CONTROL_BUTTON_BACKGROUND_INACTIVE:
++      return TP::COLOR_WINDOW_CONTROL_BUTTON_BACKGROUND_INCOGNITO_INACTIVE;
++    default:
++      return id;
++  }
++}
++
+ }  // namespace
+
+ const char ThemeHelper::kDefaultThemeID[] = "";
+@@ -258,9 +284,10 @@ SkColor ThemeHelper::GetColor(int id,
+   if (omnibox_color.has_value())
+     return omnibox_color.value();
+
+-  if (theme_supplier && !incognito) {
++  if (theme_supplier && !ShouldIgnoreThemeSupplier(id, incognito, theme_supplier)) {
+     SkColor color;
+-    if (theme_supplier->GetColor(id, &color)) {
++    const int theme_supplier_id = incognito ? GetIncognitoId(id) : id;
++    if (theme_supplier->GetColor(theme_supplier_id, &color)) {
+       if (has_custom_color)
+         *has_custom_color = true;
+       return color;
+@@ -279,7 +306,8 @@ color_utils::HSL ThemeHelper::GetTint(
+   if (theme_supplier && theme_supplier->GetTint(id, &hsl))
+     return hsl;
+
+-  return TP::GetDefaultTint(id, incognito, UseDarkModeColors(theme_supplier));
++  const bool use_incognito_tint = incognito && UseIncognitoColor(id, theme_supplier);
++  return TP::GetDefaultTint(id, use_incognito_tint, UseDarkModeColors(theme_supplier));
+ }
+
+ gfx::ImageSkia* ThemeHelper::GetImageSkiaNamed(
+@@ -454,7 +482,8 @@ SkColor ThemeHelper::GetDefaultColor(
+     }
+   }
+
+-  return TP::GetDefaultColor(id, incognito, UseDarkModeColors(theme_supplier));
++  const bool use_incognito_color = incognito && UseIncognitoColor(id, theme_supplier);
++  return TP::GetDefaultColor(id, use_incognito_color, UseDarkModeColors(theme_supplier));
+ }
+
+ // static
+@@ -739,3 +768,26 @@ SkColor ThemeHelper::GetTabGroupColor(
+   }
+   return GetTabGroupColors(id)[incognito || use_dark_mode_colors];
+ }
++
++bool ThemeHelper::UseIncognitoColor(int id,
++                                    const CustomThemeSupplier* theme_supplier) {
++  // Incognito is disabled for any non-ignored custom theme colors so they apply
++  // atop a predictable state.
++  return ShouldIgnoreThemeSupplier(id, true, theme_supplier) ||
++         (!IsCustomTheme(theme_supplier) &&
++          (!theme_supplier || theme_supplier->CanUseIncognitoColors()));
++}
++// static
++bool ThemeHelper::ShouldIgnoreThemeSupplier(
++    int id,
++    bool incognito,
++    const CustomThemeSupplier* theme_supplier) {
++  if (incognito &&
++        !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
++    return true;
++  }
++  // The incognito NTP uses the default background color instead of any theme
++  // background color, unless the theme also sets a custom background image.
++  return incognito && (id == TP::COLOR_NTP_BACKGROUND) &&
++         !HasCustomImage(IDR_THEME_NTP_BACKGROUND, theme_supplier);
++}
+diff --git a/chrome/browser/themes/theme_service.cc b/chrome/browser/themes/theme_service.cc
+index ba2d2b6..1f470c9 100644
+--- a/chrome/browser/themes/theme_service.cc
++++ b/chrome/browser/themes/theme_service.cc
+@@ -314,7 +314,9 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
+
+ CustomThemeSupplier* ThemeService::BrowserThemeProvider::GetThemeSupplier()
+     const {
+-  return incognito_ ? nullptr : delegate_->GetThemeSupplier();
++      bool should_ignore_theme_supplier =
++        incognito_ && !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes");
++  return should_ignore_theme_supplier ? nullptr : delegate_->GetThemeSupplier();
+ }
+
+ // ThemeService ---------------------------------------------------------------
+diff --git a/chrome/browser/ui/views/frame/browser_frame.cc b/chrome/browser/ui/views/frame/browser_frame.cc
+index 8ae74ec..6c18e7b 100644
+--- a/chrome/browser/ui/views/frame/browser_frame.cc
++++ b/chrome/browser/ui/views/frame/browser_frame.cc
+@@ -369,7 +369,8 @@ void BrowserFrame::SelectNativeTheme() {
+   // Select between regular, dark and GTK theme.
+   ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
+
+-  if (browser_view_->browser()->profile()->IsIncognitoProfile()) {
++  if (browser_view_->browser()->profile()->IsIncognitoProfile() &&
++      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
+     // No matter if we are using the default theme or not we always use the dark
+     // ui instance.
+     SetNativeTheme(ui::NativeTheme::GetInstanceForDarkUI());
+diff --git a/ui/views/widget/widget.cc b/ui/views/widget/widget.cc
+index 79b61d6..1cd232b 100644
+--- a/ui/views/widget/widget.cc
++++ b/ui/views/widget/widget.cc
+@@ -9,6 +9,7 @@
+
+ #include "base/auto_reset.h"
+ #include "base/bind.h"
++#include "base/command_line.h"
+ #include "base/check_op.h"
+ #include "base/containers/adapters.h"
+ #include "base/i18n/rtl.h"
+@@ -1784,7 +1785,7 @@ const ui::NativeTheme* Widget::GetNativeTheme() const {
+   if (native_theme_)
+     return native_theme_;
+
+-  if (parent_)
++  if (!base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes") && parent_)
+     return parent_->GetNativeTheme();
+
+ #if BUILDFLAG(IS_LINUX)
+--
+2.29.2.windows.2

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -1,66 +1,33 @@
---- a/chrome/browser/ungoogled_flag_entries.h
-+++ b/chrome/browser/ungoogled_flag_entries.h
-@@ -112,4 +112,8 @@
-      "Hide Extensions Menu",
-      "Hides the extensions menu (the puzzle piece icon) that allows the user to control extensions site access.  ungoogled-chromium flag.",
-      kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
-+    {"enable-incognito-themes",
-+     "Enable themes in Incognito mode",
-+     "Allows themes to override Google's built-in Incognito theming.  ungoogled-chromium flag.",
-+     kOsAll, SINGLE_VALUE_TYPE("enable-incognito-themes")},
- #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
---- a/chrome/browser/themes/theme_service.cc
-+++ b/chrome/browser/themes/theme_service.cc
-@@ -457,6 +457,10 @@
-     const BrowserThemeProviderDelegate* delegate)
-     : theme_helper_(theme_helper), incognito_(incognito), delegate_(delegate) {
-   DCHECK(delegate_);
-+  if (base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
-+    dark_ntp_ = incognito_;
-+    incognito_ = false;
-+  }
- }
-
- ThemeService::BrowserThemeProvider::~BrowserThemeProvider() = default;
-@@ -475,6 +479,8 @@
-   }
-
-   ReportHistogramBooleanUsesColorProvider(false);
-+  if (base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes"))
-+    return theme_helper_.GetColor(id, dark_ntp_ && id == TP::COLOR_NTP_BACKGROUND, GetThemeSupplier());
-   return theme_helper_.GetColor(id, incognito_, GetThemeSupplier());
- }
-
---- a/chrome/browser/themes/theme_service.h
-+++ b/chrome/browser/themes/theme_service.h
-@@ -251,6 +251,7 @@
-
-     const ThemeHelper& theme_helper_;
-     bool incognito_;
-+    bool dark_ntp_ = false;
-     raw_ptr<const BrowserThemeProviderDelegate> delegate_;
-   };
-   friend class BrowserThemeProvider;
 --- a/chrome/browser/ui/views/frame/browser_frame.cc
 +++ b/chrome/browser/ui/views/frame/browser_frame.cc
-@@ -248,8 +248,9 @@
+@@ -250,6 +250,9 @@ const ui::ThemeProvider* BrowserFrame::G
+ ui::ColorProviderManager::ThemeInitializerSupplier*
  BrowserFrame::GetCustomTheme() const {
    Browser* browser = browser_view_->browser();
-   // If this is an incognito profile, there should never be a custom theme.
--  if (browser->profile()->IsIncognitoProfile())
 +  if (browser->profile()->IsIncognitoProfile() &&
-+      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes"))
++      base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes"))
++    return ThemeService::GetThemeSupplierForProfile(browser->profile()->GetPrimaryOTRProfile(true));
+   // If this is an incognito profile, there should never be a custom theme.
+   if (browser->profile()->IsIncognitoProfile())
      return nullptr;
-   auto* app_controller = browser->app_controller();
-   // Ignore GTK+ for web apps with window-controls-overlay as the
-   // display_override so the web contents can blend with the overlay by using
-@@ -382,7 +383,8 @@
-   // Select between regular, dark and GTK theme.
+@@ -385,7 +388,8 @@ void BrowserFrame::SelectNativeTheme() {
+   // Select between regular, dark and Linux toolkit themes.
    ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
-
+ 
 -  if (browser_view_->browser()->profile()->IsIncognitoProfile()) {
 +  if (browser_view_->browser()->profile()->IsIncognitoProfile() &&
 +      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
      // No matter if we are using the default theme or not we always use the dark
      // ui instance.
      SetNativeTheme(ui::NativeTheme::GetInstanceForDarkUI());
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -120,4 +120,8 @@
+      "Hide Fullscreen Exit UI",
+      "Hides the \"X\" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode. Additionally, this hides the \"Press F11 to exit full screen\" popup. ungoogled-chromium flag.",
+      kOsLinux | kOsWin, SINGLE_VALUE_TYPE("hide-fullscreen-exit-ui")},
++    {"enable-incognito-themes",
++     "Enable themes in Incognito mode",
++     "Allows themes to override Google's built-in Incognito theming. ungoogled-chromium flag.",
++     kOsDesktop, SINGLE_VALUE_TYPE("enable-incognito-themes")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -1,16 +1,14 @@
 --- a/chrome/browser/ui/views/frame/browser_frame.cc
 +++ b/chrome/browser/ui/views/frame/browser_frame.cc
-@@ -250,6 +250,9 @@ const ui::ThemeProvider* BrowserFrame::G
- ui::ColorProviderManager::ThemeInitializerSupplier*
- BrowserFrame::GetCustomTheme() const {
+@@ -252,6 +252,7 @@ BrowserFrame::GetCustomTheme() const {
    Browser* browser = browser_view_->browser();
-+  if (browser->profile()->IsIncognitoProfile() &&
-+      base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes"))
-+    return ThemeService::GetThemeSupplierForProfile(browser->profile()->GetPrimaryOTRProfile(true));
    // If this is an incognito profile, there should never be a custom theme.
    if (browser->profile()->IsIncognitoProfile())
++   if (!base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes"))
      return nullptr;
-@@ -385,7 +388,8 @@ void BrowserFrame::SelectNativeTheme() {
+   auto* app_controller = browser->app_controller();
+   // Ignore the system theme for web apps with window-controls-overlay as the
+@@ -385,7 +386,8 @@ void BrowserFrame::SelectNativeTheme() {
    // Select between regular, dark and Linux toolkit themes.
    ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
  
@@ -20,6 +18,19 @@
      // No matter if we are using the default theme or not we always use the dark
      // ui instance.
      SetNativeTheme(ui::NativeTheme::GetInstanceForDarkUI());
+--- a/chrome/browser/ui/webui/ntp/ntp_resource_cache.cc
++++ b/chrome/browser/ui/webui/ntp/ntp_resource_cache.cc
+@@ -432,7 +432,9 @@ void NTPResourceCache::CreateNewTabIncog
+       profile_->GetPrefs()->GetString(prefs::kCurrentThemeID);
+ 
+   // Colors.
+-  const ui::ColorProvider& cp = web_contents->GetColorProvider();
++  auto key = native_theme->GetColorProviderKey(nullptr);
++  key.color_mode = ui::ColorProviderManager::ColorMode::kDark;
++  const ui::ColorProvider& cp = *ui::ColorProviderManager::Get().GetColorProviderFor(key);
+   substitutions["colorBackground"] = color_utils::SkColorToRgbaString(
+       GetThemeColor(native_theme, cp, kColorNewTabPageBackground));
+   substitutions["backgroundPosition"] = GetNewTabBackgroundPositionCSS(tp);
 --- a/chrome/browser/ungoogled_flag_entries.h
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -120,4 +120,8 @@

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -22,7 +22,7 @@
  }
 
  ThemeService::BrowserThemeProvider::~BrowserThemeProvider() = default;
-@@ -475,6 +475,8 @@
+@@ -475,6 +479,8 @@
    }
 
    ReportHistogramBooleanUsesColorProvider(false);
@@ -54,7 +54,7 @@
    auto* app_controller = browser->app_controller();
    // Ignore GTK+ for web apps with window-controls-overlay as the
    // display_override so the web contents can blend with the overlay by using
-@@ -382,7 +382,8 @@
+@@ -382,7 +383,8 @@
    // Select between regular, dark and GTK theme.
    ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
 

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -1,6 +1,6 @@
 --- a/chrome/browser/ungoogled_flag_entries.h
 +++ b/chrome/browser/ungoogled_flag_entries.h
-@@ -100,4 +100,8 @@
+@@ -112,4 +112,8 @@
       "Custom HTTP Accept Header",
       "Set a custom value for the Accept header which is sent by the browser with every HTTP request.  (e.g. `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`).  ungoogled-chromium flag.",
       kOsAll, ORIGIN_LIST_VALUE_TYPE("http-accept-header", "")},
@@ -9,210 +9,58 @@
 +     "Allows themes to override Google's built-in Incognito theming.  ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("enable-incognito-themes")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
---- a/chrome/browser/themes/theme_helper.cc
-+++ b/chrome/browser/themes/theme_helper.cc
-@@ -4,6 +4,7 @@
-
- #include "chrome/browser/themes/theme_service.h"
-
-+#include "base/command_line.h
- #include "base/feature_list.h"
- #include "base/no_destructor.h"
- #include "build/build_config.h"
-@@ -171,6 +172,32 @@ SeparatorColorCache& GetSeparatorColorCache() {
-   return *cache;
- }
-
-+// For legacy reasons, the theme supplier requires the incognito variants of
-+// color IDs.  This converts from normal to incognito IDs where they exist.
-+int GetIncognitoId(int id) {
-+  switch (id) {
-+    case TP::COLOR_FRAME_ACTIVE:
-+      return TP::COLOR_FRAME_ACTIVE_INCOGNITO;
-+    case TP::COLOR_FRAME_INACTIVE:
-+      return TP::COLOR_FRAME_INACTIVE_INCOGNITO;
-+    case TP::COLOR_TAB_BACKGROUND_INACTIVE_FRAME_ACTIVE:
-+      return TP::COLOR_TAB_BACKGROUND_INACTIVE_FRAME_ACTIVE_INCOGNITO;
-+    case TP::COLOR_TAB_BACKGROUND_INACTIVE_FRAME_INACTIVE:
-+      return TP::COLOR_TAB_BACKGROUND_INACTIVE_FRAME_INACTIVE_INCOGNITO;
-+    case TP::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE:
-+      return TP::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_ACTIVE_INCOGNITO;
-+    case TP::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_INACTIVE:
-+      return TP::COLOR_TAB_FOREGROUND_INACTIVE_FRAME_INACTIVE_INCOGNITO;
-+    case TP::COLOR_WINDOW_CONTROL_BUTTON_BACKGROUND_ACTIVE:
-+      return TP::COLOR_WINDOW_CONTROL_BUTTON_BACKGROUND_INCOGNITO_ACTIVE;
-+    case TP::COLOR_WINDOW_CONTROL_BUTTON_BACKGROUND_INACTIVE:
-+      return TP::COLOR_WINDOW_CONTROL_BUTTON_BACKGROUND_INCOGNITO_INACTIVE;
-+    default:
-+      return id;
-+  }
-+}
-+
-+
- }  // namespace
-
- const char ThemeHelper::kDefaultThemeID[] = "";
-@@ -281,9 +308,11 @@ SkColor ThemeHelper::GetColor(int id,
-                               const CustomThemeSupplier* theme_supplier) const {
-   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-
--  if (theme_supplier && !incognito) {
-+  if (theme_supplier &&
-+        !ShouldIgnoreThemeSupplier(id, incognito, theme_supplier)) {
-     SkColor color;
--    if (theme_supplier->GetColor(id, &color))
-+    const int theme_supplier_id = incognito ? GetIncognitoId(id) : id;
-+    if (theme_supplier->GetColor(theme_supplier_id, &color))
-       return color;
-   }
-
-@@ -299,7 +328,8 @@ color_utils::HSL ThemeHelper::GetTint(
-   if (theme_supplier && theme_supplier->GetTint(id, &hsl))
-     return hsl;
-
--  return TP::GetDefaultTint(id, incognito, UseDarkModeColors(theme_supplier));
-+  const bool use_incognito_tint = incognito && UseIncognitoColor(id, theme_supplier);
-+  return TP::GetDefaultTint(id, use_incognito_tint, UseDarkModeColors(theme_supplier));
- }
-
- gfx::ImageSkia* ThemeHelper::GetImageSkiaNamed(
-@@ -554,7 +584,18 @@ SkColor ThemeHelper::GetDefaultColor(
-                       incognito, theme_supplier);
-   }
-
--  return TP::GetDefaultColor(id, incognito, UseDarkModeColors(theme_supplier));
-+  const bool use_incognito_color = incognito && UseIncognitoColor(id, theme_supplier);
-+  return TP::GetDefaultColor(id, use_incognito_color, UseDarkModeColors(theme_supplier));
-+}
-+
-+// static
-+bool ThemeHelper::UseIncognitoColor(int id,
-+                                    const CustomThemeSupplier* theme_supplier) {
-+  // Incognito is disabled for any non-ignored custom theme colors so they apply
-+  // atop a predictable state.
-+  return ShouldIgnoreThemeSupplier(id, true, theme_supplier) ||
-+         (!IsCustomTheme(theme_supplier) &&
-+          (!theme_supplier || theme_supplier->CanUseIncognitoColors()));
- }
-
- // static
-@@ -565,6 +606,20 @@ bool ThemeHelper::UseDarkModeColors(const CustomThemeSupplier* theme_supplier) {
-          ui::NativeTheme::GetInstanceForNativeUi()->ShouldUseDarkColors();
- }
-
-+// static
-+bool ThemeHelper::ShouldIgnoreThemeSupplier(
-+    int id,
-+    bool incognito,
-+    const CustomThemeSupplier* theme_supplier) {
-+  if (incognito && !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
-+    return true;
-+  }
-+  // The incognito NTP uses the default background color instead of any theme
-+  // background color, unless the theme also sets a custom background image.
-+  return incognito && (id == TP::COLOR_NTP_BACKGROUND) &&
-+         !HasCustomImage(IDR_THEME_NTP_BACKGROUND, theme_supplier);
-+}
-+
- gfx::Image ThemeHelper::GetImageNamed(
-     int id,
-     bool incognito,
-     --- a/chrome/browser/themes/theme-helper.h
-+++ b/chrome/browser/themes/theme-helper.h
-@@ -110,9 +110,21 @@ class ThemeHelper {
-  private:
-   friend class theme_service_internal::ThemeServiceTest;
-
-+  // Whether the default incognito color/tint for |id| should be used, if
-+  // available.
-+  static bool UseIncognitoColor(int id,
-+                                const CustomThemeSupplier* theme_supplier);
-+
-   // Whether dark default colors/tints should be used, if available.
-   static bool UseDarkModeColors(const CustomThemeSupplier* theme_supplier);
-
-+  // Whether the color from |theme_supplier| (if any) should be ignored for
-+  // the given |id| and |incognito| state.
-+  static bool ShouldIgnoreThemeSupplier(
-+      int id,
-+      bool incognito,
-+      const CustomThemeSupplier* theme_supplier);
-+
-   // Returns a cross platform image for an id.
-   gfx::Image GetImageNamed(int id,
-                            bool incognito,
 --- a/chrome/browser/themes/theme_service.cc
 +++ b/chrome/browser/themes/theme_service.cc
-@@ -507,7 +507,7 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
-     if (auto provider_color_id = ThemeProviderColorIdToColorId(id)) {
-       const ui::NativeTheme* native_theme = nullptr;
-
--      if (incognito_) {
-+      if (incognito_ && !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
-         native_theme = ui::NativeTheme::GetInstanceForDarkUI();
-       } else {
-         native_theme = ui::NativeTheme::GetInstanceForNativeUi();
-@@ -532,7 +532,8 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
-
- CustomThemeSupplier* ThemeService::BrowserThemeProvider::GetThemeSupplier()
-     const {
--  return incognito_ ? nullptr : delegate_->GetThemeSupplier();
-+      const bool ignore_theme_supplier = incognito_ && !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes");
-+  return ignore_theme_supplier ? nullptr : delegate_->GetThemeSupplier();
+@@ -457,6 +457,10 @@
+     const BrowserThemeProviderDelegate* delegate)
+     : theme_helper_(theme_helper), incognito_(incognito), delegate_(delegate) {
+   DCHECK(delegate_);
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
++    dark_ntp_ = incognito_;
++    incognito_ = false;
++  }
  }
 
- // ThemeService ---------------------------------------------------------------
-@@ -772,7 +773,9 @@ ThemeSyncableService* ThemeService::GetThemeSyncableService() const {
- const ui::ThemeProvider& ThemeService::GetThemeProviderForProfile(
-     Profile* profile) {
-   ThemeService* service = ThemeServiceFactory::GetForProfile(profile);
--  return profile->IsIncognitoProfile() ? service->incognito_theme_provider_
-+  const bool use_incognito_provider = profile->IsIncognitoProfile() &&
-+      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes");
-+  return use_incognito_provider ? service->incognito_theme_provider_
-                                        : service->original_theme_provider_;
+ ThemeService::BrowserThemeProvider::~BrowserThemeProvider() = default;
+@@ -475,6 +475,8 @@
+   }
+
+   ReportHistogramBooleanUsesColorProvider(false);
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes"))
++    return theme_helper_.GetColor(id, dark_ntp_ && id == TP::COLOR_NTP_BACKGROUND, GetThemeSupplier());
+   return theme_helper_.GetColor(id, incognito_, GetThemeSupplier());
  }
 
+--- a/chrome/browser/themes/theme_service.h
++++ b/chrome/browser/themes/theme_service.h
+@@ -251,6 +251,7 @@
+
+     const ThemeHelper& theme_helper_;
+     bool incognito_;
++    bool dark_ntp_ = false;
+     raw_ptr<const BrowserThemeProviderDelegate> delegate_;
+   };
+   friend class BrowserThemeProvider;
 --- a/chrome/browser/ui/views/frame/browser_frame.cc
 +++ b/chrome/browser/ui/views/frame/browser_frame.cc
-@@ -248,8 +248,10 @@ ui::ColorProviderManager::ThemeInitializerSupplier*
+@@ -248,8 +248,9 @@
  BrowserFrame::GetCustomTheme() const {
    Browser* browser = browser_view_->browser();
    // If this is an incognito profile, there should never be a custom theme.
 -  if (browser->profile()->IsIncognitoProfile())
 +  if (browser->profile()->IsIncognitoProfile() &&
-+      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
++      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes"))
      return nullptr;
-+  }
    auto* app_controller = browser->app_controller();
    // Ignore GTK+ for web apps with window-controls-overlay as the
    // display_override so the web contents can blend with the overlay by using
-@@ -382,7 +384,8 @@ void BrowserFrame::SelectNativeTheme() {
+@@ -382,7 +382,8 @@
    // Select between regular, dark and GTK theme.
    ui::NativeTheme* native_theme = ui::NativeTheme::GetInstanceForNativeUi();
 
 -  if (browser_view_->browser()->profile()->IsIncognitoProfile()) {
 +  if (browser_view_->browser()->profile()->IsIncognitoProfile() &&
-+        !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
++      !base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes")) {
      // No matter if we are using the default theme or not we always use the dark
      // ui instance.
      SetNativeTheme(ui::NativeTheme::GetInstanceForDarkUI());
---- a/ui/views/widget/widget.cc
-+++ b/ui/views/widget/widget.cc
-@@ -10,6 +10,7 @@
- #include "base/auto_reset.h"
- #include "base/bind.h"
- #include "base/check_op.h"
-+#include "base/command_line.h"
- #include "base/containers/adapters.h"
- #include "base/i18n/rtl.h"
- #include "base/notreached.h"
-@@ -1818,7 +1819,7 @@ const ui::NativeTheme* Widget::GetNativeTheme() const {
-   if (native_theme_)
-     return native_theme_;
-
--  if (parent_)
-+  if (!base::CommandLine::ForCurrentProcess()->HasSwitch("enable-incognito-themes") && parent_)
-     return parent_->GetNativeTheme();
-
- #if BUILDFLAG(IS_LINUX)

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -1,9 +1,9 @@
 --- a/chrome/browser/ungoogled_flag_entries.h
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -112,4 +112,8 @@
-      "Custom HTTP Accept Header",
-      "Set a custom value for the Accept header which is sent by the browser with every HTTP request.  (e.g. `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`).  ungoogled-chromium flag.",
-      kOsAll, ORIGIN_LIST_VALUE_TYPE("http-accept-header", "")},
+     "Hide Extensions Menu",
+     "Hides the extensions menu (the puzzle piece icon) that allows the user to control extensions site access.  ungoogled-chromium flag.",
+     kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
 +    {"enable-incognito-themes",
 +     "Enable themes in Incognito mode",
 +     "Allows themes to override Google's built-in Incognito theming.  ungoogled-chromium flag.",

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -111,8 +111,6 @@
 +  return incognito && (id == TP::COLOR_NTP_BACKGROUND) &&
 +         !HasCustomImage(IDR_THEME_NTP_BACKGROUND, theme_supplier);
 +}
-diff --git a/chrome/browser/themes/theme_service.cc b/chrome/browser/themes/theme_service.cc
-index ba2d2b6..1f470c9 100644
 --- a/chrome/browser/themes/theme_service.cc
 +++ b/chrome/browser/themes/theme_service.cc
 @@ -314,7 +314,9 @@ ThemeService::BrowserThemeProvider::GetColorProviderColor(int id) const {
@@ -126,8 +124,6 @@ index ba2d2b6..1f470c9 100644
  }
 
  // ThemeService ---------------------------------------------------------------
-diff --git a/chrome/browser/ui/views/frame/browser_frame.cc b/chrome/browser/ui/views/frame/browser_frame.cc
-index 8ae74ec..6c18e7b 100644
 --- a/chrome/browser/ui/views/frame/browser_frame.cc
 +++ b/chrome/browser/ui/views/frame/browser_frame.cc
 @@ -369,7 +369,8 @@ void BrowserFrame::SelectNativeTheme() {
@@ -140,8 +136,6 @@ index 8ae74ec..6c18e7b 100644
      // No matter if we are using the default theme or not we always use the dark
      // ui instance.
      SetNativeTheme(ui::NativeTheme::GetInstanceForDarkUI());
-diff --git a/ui/views/widget/widget.cc b/ui/views/widget/widget.cc
-index 79b61d6..1cd232b 100644
 --- a/ui/views/widget/widget.cc
 +++ b/ui/views/widget/widget.cc
 @@ -9,6 +9,7 @@

--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -161,5 +161,3 @@ index 79b61d6..1cd232b 100644
      return parent_->GetNativeTheme();
 
  #if BUILDFLAG(IS_LINUX)
---
-2.29.2.windows.2

--- a/patches/series
+++ b/patches/series
@@ -102,3 +102,4 @@ extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch
 extra/ungoogled-chromium/add-flag-for-disabling-link-drag.patch
 extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
 extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
+extra/ungoogled-chromium/add-flag-for-incognito-themes.patch


### PR DESCRIPTION
This PR is intended to add a flag that allows themes to be active in Incognito windows, fixing #1928. I was as irritated by the change as ssokolow over there seems to be, and some diving on the public Chromium repo led me to the commit that I'm pretty sure is responsible.

However, I don't have any relevant experience with C++ proper (beyond a bit of familiarity with C-like syntax), or with .patch files, and I am unable to do an actual build to test whether it works as intended. This is entirely cargo-cult programming and I would not be surprised if it has easy-to-catch errors that I don't know enough to notice. 