### PR TITLE
Add flags to hide SharingHub and SidePanel buttons.  Small cleanup.

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -12,19 +12,19 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   <code>Switch&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
   -- | --
   `--disable-beforeunload` | Disables JavaScript dialog boxes triggered by `beforeunload`
+  `--disable-grease-tls` | Disables GREASE for TLS. Combined with `--http-accept-header` allows browser to look more like a tor-browser. See https://github.com/ungoogled-software/ungoogled-chromium/issues/783 for more details.
   `--disable-search-engine-collection` | Disable automatic search engine scraping from webpages.
   `--extension-mime-request-handling` | Change how extension MIME types (CRX and user scripts) are handled. Acceptable values are `download-as-regular-file` or `always-prompt-for-install`. Leave unset to use normal behavior.
   `--fingerprinting-canvas-image-data-noise` | (Added flag to Bromite feature) Implements fingerprinting deception for Canvas image data retrieved via JS APIs. In the data, at most 10 pixels are slightly modified.
   `--fingerprinting-canvas-measuretext-noise` | (Added flag to Bromite feature) Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.
   `--fingerprinting-client-rects-noise` | (Added flag to Bromite feature) Implements fingerprinting deception of JS APIs `getClientRects()` and `getBoundingClientRect()` by scaling their output values with a random factor in the range -0.0003% to 0.0003%, which are recomputed for every document instantiation.
   `--hide-crashed-bubble` | Hides the bubble box with the message "Restore Pages? Chromium didn't shut down correctly." that shows on startup after the browser did not exit cleanly.
+  `--http-accept-header` | Changes the default value of the `Accept` HTTP header sent with HTTP requests. Combined with `--disable-grease-tls` allows browser to look more like a tor-browser. See https://github.com/ungoogled-software/ungoogled-chromium/issues/783 for more details.
   `--keep-old-history` | Disables deletion of local browser history after 90 days
   `--max-connections-per-host` | (from Bromite) Configure the maximum allowed connections per host. Valid values are `6` and `15`
   `--omnibox-autocomplete-filtering` | Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages.  Accepts `search`, `search-bookmarks`, `search-chrome`, and `search-bookmarks-chrome`.
   `--popups-to-tabs` | Makes popups open in new tabs.
   `--referrer-directive` | Allows setting a custom directive for referrer headers. Accepts `nocrossorigin`, `minimal`, and `noreferrers`. The no cross-origin referrer option removes all cross-origin referrers, the minimal option removes all cross-origin referrers and strips same-origin referrers down to the origin, and the no referrers option removes all referrers.
-  `--http-accept-header` | Changes the default value of the `Accept` HTTP header sent with HTTP requests. Combined with `--disable-grease-tls` allows browser to look more like a tor-browser. See https://github.com/ungoogled-software/ungoogled-chromium/issues/783 for more details.
-  `--disable-grease-tls` | Disables GREASE for TLS. Combined with `--http-accept-header` allows browser to look more like a tor-browser. See https://github.com/ungoogled-software/ungoogled-chromium/issues/783 for more details.
 
 - ### Available only on desktop
 
@@ -56,13 +56,13 @@ These are also available on the `chrome://flags` page.
 
 - ### Available on all platforms
 
-  <code>Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
+  Feature | Description
   -- | --
   `SetIpv6ProbeFalse` | Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.
 
 - ### Available only on desktop
 
-  <code>Feature&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</code> | Description
+  Feature | Description
   -- | --
   `ClearDataOnExit` | Clears all browsing data on exit.
   `DisableQRGenerator` | Disables the QR generator for sharing page links.

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -34,6 +34,8 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--close-confirmation` | Show a warning prompt when closing the browser window. Accepts `last` (prompt when closing the last window with several tabs) and `multiple` (prompt only if more than one window is open). 
   `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed.  Only takes the value `never`.
   `--custom-ntp` | Allows setting a custom URL for the new tab page.  Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  This applies for incognito windows as well when not set to a `chrome://` internal page.
+  `--disable-sharing-hub` | Disables the sharing hub button.
+  `--hide-sidepanel-button` | Hides the SidePanel Button.
   `--hide-tab-close-buttons` | Hides the close buttons on tabs.
   `--remove-grab-handle` | Removes the reserved empty space in the tabstrip for moving the window.
   `--remove-tabsearch-button` | Removes the tabsearch button from the tabstrip.

--- a/patches/extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
+++ b/patches/extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
@@ -44,7 +44,7 @@
  #endif  // CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
 --- a/content/browser/BUILD.gn
 +++ b/content/browser/BUILD.gn
-@@ -230,6 +230,7 @@ source_set("browser") {
+@@ -231,6 +231,7 @@ source_set("browser") {
      "//third_party/libyuv",
      "//third_party/re2",
      "//third_party/sqlite",

--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-sharing-hub.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-sharing-hub.patch
@@ -1,0 +1,29 @@
+--- a/chrome/browser/sharing_hub/sharing_hub_features.cc
++++ b/chrome/browser/sharing_hub/sharing_hub_features.cc
+@@ -4,6 +4,7 @@
+ 
+ #include "chrome/browser/sharing_hub/sharing_hub_features.h"
+ 
++#include "base/command_line.h"
+ #include "build/build_config.h"
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/share/share_features.h"
+@@ -39,6 +40,7 @@ bool ScreenshotsDisabledByPolicy(content
+ }  // namespace
+ 
+ bool SharingHubOmniboxEnabled(content::BrowserContext* context) {
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("disable-sharing-hub")) return false;
+ #if BUILDFLAG(IS_CHROMEOS)
+   return false;
+ #else
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -100,4 +100,8 @@
+      "Custom HTTP Accept Header",
+      "Set a custom value for the Accept header which is sent by the browser with every HTTP request.  (e.g. `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`).  ungoogled-chromium flag.",
+      kOsAll, ORIGIN_LIST_VALUE_TYPE("http-accept-header", "")},
++    {"disable-sharing-hub",
++     "Disable Sharing Hub",
++     "Disables the sharing hub button.  ungoogled-chromium flag.",
++     kOsDesktop, SINGLE_VALUE_TYPE("disable-sharing-hub")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch
@@ -1,0 +1,21 @@
+--- a/chrome/browser/ui/views/frame/browser_view.cc
++++ b/chrome/browser/ui/views/frame/browser_view.cc
+@@ -895,6 +895,7 @@ BrowserView::BrowserView(std::unique_ptr
+   contents_container_ = AddChildView(std::move(contents_container));
+   set_contents_view(contents_container_);
+ 
++  if (!base::CommandLine::ForCurrentProcess()->HasSwitch("hide-sidepanel-button"))
+     right_aligned_side_panel_ = AddChildView(std::make_unique<SidePanel>(this));
+     right_aligned_side_panel_separator_ =
+         AddChildView(std::make_unique<ContentsSeparator>());
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -104,4 +104,8 @@
+      "Disable Sharing Hub",
+      "Disables the sharing hub button.  ungoogled-chromium flag.",
+      kOsDesktop, SINGLE_VALUE_TYPE("disable-sharing-hub")},
++    {"hide-sidepanel-button",
++     "Hide SidePanel Button",
++     "Hides the SidePanel Button.  ungoogled-chromium flag.",
++     kOsDesktop, SINGLE_VALUE_TYPE("hide-sidepanel-button")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -99,3 +99,5 @@ extra/ungoogled-chromium/disable-remote-optimization-guide.patch
 extra/ungoogled-chromium/add-flag-for-referrer-header.patch
 extra/ungoogled-chromium/add-flag-to-disable-tls-grease.patch
 extra/ungoogled-chromium/add-flag-to-change-http-accept-header.patch
+extra/ungoogled-chromium/add-flag-to-disable-sharing-hub.patch
+extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch

--- a/patches/series
+++ b/patches/series
@@ -35,6 +35,7 @@ core/ungoogled-chromium/disable-privacy-sandbox.patch
 core/ungoogled-chromium/doh-changes.patch
 core/bromite/disable-fetching-field-trials.patch
 
+extra/ungoogled-chromium/add-ungoogled-flag-headers.patch
 extra/inox-patchset/0006-modify-default-prefs.patch
 extra/inox-patchset/0008-restore-classic-ntp.patch
 extra/inox-patchset/0013-disable-missing-key-warning.patch
@@ -52,8 +53,10 @@ extra/iridium-browser/prefs-always-prompt-for-download-directory-by-defaul.patch
 extra/iridium-browser/updater-disable-auto-update.patch
 extra/iridium-browser/Remove-EV-certificates.patch
 extra/iridium-browser/browser-disable-profile-auto-import-on-first-run.patch
+extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
+extra/bromite/flag-max-connections-per-host.patch
+extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch
 extra/ungoogled-chromium/add-components-ungoogled.patch
-extra/ungoogled-chromium/add-ungoogled-flag-headers.patch
 extra/ungoogled-chromium/disable-formatting-in-omnibox.patch
 extra/ungoogled-chromium/add-ipv6-probing-option.patch
 extra/ungoogled-chromium/remove-disable-setuid-sandbox-as-bad-flag.patch
@@ -94,8 +97,5 @@ extra/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
 extra/ungoogled-chromium/add-flag-to-hide-tab-close-buttons.patch
 extra/ungoogled-chromium/disable-remote-optimization-guide.patch
 extra/ungoogled-chromium/add-flag-for-referrer-header.patch
-extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
-extra/bromite/flag-max-connections-per-host.patch
-extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch
 extra/ungoogled-chromium/add-flag-to-disable-tls-grease.patch
 extra/ungoogled-chromium/add-flag-to-change-http-accept-header.patch


### PR DESCRIPTION
This PR adds two new patches that add flags to remove the sharing hub and the sidpanel buttons with `--disable-sharing-hub` and `--hide-sidepanel-button` respectively.  

I've also included a commit that reorders some entries in the flags doc and removes the non-breaking spaces from the feature flag section since they shouldn't cause line breaks due to not containing hyphens.  It also moves the bromite flags in the series file further up the list so new entries can simply be added to the end of the list.  Historically the order mattered, but since the flag headers patch was added it hasn't been necessary.  