### PR TITLE
Add flag to hide the extensions menu (the puzzle piece icon)

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -36,6 +36,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--custom-ntp` | Allows setting a custom URL for the new tab page.  Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  This applies for incognito windows as well when not set to a `chrome://` internal page.
   `--disable-sharing-hub` | Disables the sharing hub button.
   `--hide-sidepanel-button` | Hides the SidePanel Button.
+  `--hide-extensions-menu` | Hides the extensions menu (the puzzle piece icon) that allows the user to control extensions site access.
   `--hide-tab-close-buttons` | Hides the close buttons on tabs.
   `--remove-grab-handle` | Removes the reserved empty space in the tabstrip for moving the window.
   `--remove-tabsearch-button` | Removes the tabsearch button from the tabstrip.

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
@@ -1,0 +1,21 @@
+--- a/chrome/browser/ui/views/toolbar/toolbar_view.cc
++++ b/chrome/browser/ui/views/toolbar/toolbar_view.cc
+@@ -255,6 +255,7 @@ void ToolbarView::Init() {
+   // Do not create the extensions or browser actions container if it is a guest
+   // profile (only regular and incognito profiles host extensions).
+   if (!browser_->profile()->IsGuestSession()) {
++    if (!base::CommandLine::ForCurrentProcess()->HasSwitch("hide-extensions-menu"))
+     extensions_container =
+         std::make_unique<ExtensionsToolbarContainer>(browser_);
+   }
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -108,4 +108,8 @@
+      "Hide SidePanel Button",
+      "Hides the SidePanel Button.  ungoogled-chromium flag.",
+      kOsDesktop, SINGLE_VALUE_TYPE("hide-sidepanel-button")},
++    {"hide-extensions-menu",
++     "Hide Extensions Menu",
++     "Hides the extensions menu (the puzzle piece icon) that allows the user to control extensions site access.  ungoogled-chromium flag.",
++     kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -101,3 +101,4 @@ extra/ungoogled-chromium/add-flag-to-disable-tls-grease.patch
 extra/ungoogled-chromium/add-flag-to-change-http-accept-header.patch
 extra/ungoogled-chromium/add-flag-to-disable-sharing-hub.patch
 extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch
+extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch


### PR DESCRIPTION
This pull request solves #1336.

The patch has been tested only on Windows. An automatic build by Github Actions can be found at
https://github.com/jwangac/ungoogled-chromium-windows/releases/tag/test

This pull request might be postponed after updating Chromium to 103.0.5060.53 (by  #1993).
