### PR TITLE
Re-add flag to hide the extensions menu (the puzzle piece icon)

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -36,6 +36,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed. Only takes the value `never`.
   `--custom-ntp` | Allows setting a custom URL for the new tab page. Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`). This applies for incognito windows as well when not set to a `chrome://` internal page.
   `--disable-sharing-hub` | Disables the sharing hub button.
+  `--hide-extensions-menu` | Hides the extensions menu (the puzzle piece icon).
   `--hide-sidepanel-button` | Hides the SidePanel Button.
   `--hide-tab-close-buttons` | Hides the close buttons on tabs.
   `--remove-grab-handle` | Removes the reserved empty space in the tabstrip for moving the window.

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
@@ -1,0 +1,57 @@
+--- a/chrome/browser/ui/views/extensions/extensions_toolbar_container.cc
++++ b/chrome/browser/ui/views/extensions/extensions_toolbar_container.cc
+@@ -7,6 +7,7 @@
+ #include <memory>
+ #include "base/bind.h"
+ #include "base/callback_helpers.h"
++#include "base/command_line.h"
+ #include "base/cxx17_backports.h"
+ #include "base/feature_list.h"
+ #include "base/no_destructor.h"
+@@ -26,6 +27,7 @@
+ #include "chrome/browser/ui/views/extensions/extensions_toolbar_button.h"
+ #include "chrome/browser/ui/views/frame/browser_view.h"
+ #include "chrome/browser/ui/views/toolbar/toolbar_actions_bar_bubble_views.h"
++#include "chrome/browser/ui/views/toolbar/toolbar_view.h"
+ #include "chrome/browser/ui/views/web_apps/frame_toolbar/web_app_frame_toolbar_view.h"
+ #include "extensions/common/extension_features.h"
+ #include "ui/base/dragdrop/drag_drop_types.h"
+@@ -318,6 +320,17 @@ void ExtensionsToolbarContainer::AnchorA
+   widget->widget_delegate()->AsBubbleDialogDelegate()->SetAnchorView(
+       anchor_view && anchor_view->GetVisible() ? anchor_view
+                                                : GetExtensionsButton());
++
++  // Fix the position of widgets. Without this fix, extension-installed-bubble
++  // and extension-uninstall-dialog may be out of the window border on Linux.
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("hide-extensions-menu"))
++  {
++    views::View* anchor_view = BrowserView::GetBrowserViewForBrowser(browser_)
++      ->toolbar_button_provider()->GetAppMenuButton();
++    widget->widget_delegate()->AsBubbleDialogDelegate()
++      ->SetAnchorView(anchor_view);
++  }
++
+   widget->Show();
+ }
+ 
+@@ -810,6 +823,9 @@ void ExtensionsToolbarContainer::UpdateC
+ }
+ 
+ bool ExtensionsToolbarContainer::ShouldContainerBeVisible() const {
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("hide-extensions-menu"))
++    return false;
++
+   // The container (and extensions-menu button) should not be visible if we have
+   // no extensions.
+   if (!HasAnyExtensions())
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -112,4 +112,8 @@
+      "Disable link drag",
+      "Prevents dragging of links and selected text. ungoogled-chromium flag.",
+      kOsDesktop, FEATURE_VALUE_TYPE(blink::features::kDisableLinkDrag)},
++    {"hide-extensions-menu",
++     "Hide Extensions Menu",
++     "Hides the extensions menu (the puzzle piece icon). ungoogled-chromium flag.",
++     kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -100,3 +100,4 @@ extra/ungoogled-chromium/add-flag-to-change-http-accept-header.patch
 extra/ungoogled-chromium/add-flag-to-disable-sharing-hub.patch
 extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch
 extra/ungoogled-chromium/add-flag-for-disabling-link-drag.patch
+extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch


### PR DESCRIPTION
This PR replaces my previous PR #1994. The previous PR is reverted because it
causes ungoogled-chromium to crash.

This PR re-adds the flag that allows one to hide the extensions menu (the
puzzle piece icon), by patching [the menu's visibility logic](https://github.com/chromium/chromium/blob/0f4ff69f75ce13ac45815a53000c36e7401561a5/chrome/browser/ui/views/extensions/extensions_toolbar_container.cc#L804):

```patch
 bool ExtensionsToolbarContainer::ShouldContainerBeVisible() const {
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch("hide-extensions-menu"))
+    return false;
+
   // The container (and extensions-menu button) should not be visible if we have
   // no extensions.
   if (!HasAnyExtensions())
     return false;

   // All other display modes are constantly visible.
   if (display_mode_ != DisplayMode::kAutoHide)
     return true;

   if (GetAnimatingLayoutManager()->is_animating())
     return true;

   // Is menu showing.
   if (GetExtensionsButton()->GetExtensionsMenuShowing())
     return true;

   // Is extension pop out is showing.
   if (popped_out_action_)
     return true;

   // Is extension pop up showing.
   if (popup_owner_)
     return true;

   return false;
 }
```

I test the patch on [Windows](https://github.com/jwangac/ungoogled-chromium-windows/releases/tag/103.0.5060.53-test). The patch works and avoids previous crashes

1. when installing a packed extension
2. when loading an unpacked extension
3. when packing an extension

(Thanks Rusenche for reporting these crash cases.)

But my test can be incomplete as I'm not a heavy extension user or developer.
This PR is marked as draft. I'm wondering if someone can help testing it in 
more use-cases.

This patch has some limitations.

1. The flag will hide all pinned extensions. One cannot hide only the puzzle
piece icon but keep pinned extensions.

2. Notification like `[Extension Name] has been added to Chromium` (shows after
installing an extension) and `Remove "[Extension Name]"?` (shows when removing
an extension) cannot find the hidden extension icon to attach. The notification
will show at the left-top corner.
