### PR TITLE
Per-platform version check

### DIFF
--- a/.github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md
+++ b/.github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md
@@ -1,13 +1,13 @@
 ---
 name: Create an "Updating to Chromium x.x.x.x"
 about: For letting the community track progress to a new stable Chromium
-title: Updating to Chromium {{ env.VERSION }}
+title: Updating to Chromium {{ env.VERSION }} on {{ env.PLATFORM }}
 labels: update
 assignees: ''
 
 ---
 
-Chromium stable channel for Linux has been updated to a newer version: {{ env.VERSION }}.
+Chromium stable channel for {{ env.PLATFORM }} has been updated to a newer version: {{ env.VERSION }}.
 
 If you are willing to work on updating the patches and lists, please leave a comment in this issue in order to facilitate better coordination and avoid wasted/duplicated efforts.
 

--- a/.github/workflows/new_version_check.yml
+++ b/.github/workflows/new_version_check.yml
@@ -13,15 +13,61 @@ jobs:
     if: github.repository == 'ungoogled-software/ungoogled-chromium'
     runs-on: ubuntu-latest
     steps:
-      - name: Get the latest Linux version
+      - name: Get the latest Chromium version
         id: latest-version
-        run: echo "::set-output name=version::$( curl -s https://omahaproxy.appspot.com/linux )"
+        run: |
+          echo "::set-output name=linux_version::$( curl -s https://omahaproxy.appspot.com/linux )"
+          echo "::set-output name=win_version::$( curl -s https://omahaproxy.appspot.com/win )"
+          echo "::set-output name=mac_version::$( curl -s https://omahaproxy.appspot.com/mac )"
       - uses: actions/checkout@v2
-      - name: Create Issue
+      - name: Create Issue for all platforms
+        if: |
+          contains( steps.latest-version.outputs.win_version, steps.latest-version.outputs.mac_version ) &&
+          contains( steps.latest-version.outputs.mac_version, steps.latest-version.outputs.linux_version )   
         uses: dblock/create-a-github-issue@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.latest-version.outputs.version }}
+          VERSION: ${{ steps.latest-version.outputs.linux_version }}
+          PLATFORM: all platforms
+        with:
+          update_existing: false
+          search_existing: all
+          filename:  .github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md
+      - name: Create Issue for Linux
+        if: |
+          ! contains( steps.latest-version.outputs.win_version, steps.latest-version.outputs.mac_version ) ||
+          ! contains( steps.latest-version.outputs.mac_version, steps.latest-version.outputs.linux_version )    
+        uses: dblock/create-a-github-issue@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.latest-version.outputs.linux_version }}
+          PLATFORM: Linux
+        with:
+          update_existing: false
+          search_existing: all
+          filename:  .github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md
+      - name: Create Issue for macOS
+        if: |
+          ! contains( steps.latest-version.outputs.win_version, steps.latest-version.outputs.mac_version ) ||
+          ! contains( steps.latest-version.outputs.mac_version, steps.latest-version.outputs.linux_version )     	    
+        uses: dblock/create-a-github-issue@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.latest-version.outputs.mac_version }}
+          PLATFORM: macOS
+        with:
+          update_existing: false
+          search_existing: all
+          filename:  .github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md
+      - name: Create Issue for Windows
+        if: |
+          ! contains( steps.latest-version.outputs.win_version, steps.latest-version.outputs.mac_version ) ||
+          ! contains( steps.latest-version.outputs.mac_version, steps.latest-version.outputs.linux_version )  
+        uses: dblock/create-a-github-issue@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ steps.latest-version.outputs.win_version }}
+          PLATFORM: Windows
         with:
           update_existing: false
           search_existing: all


### PR DESCRIPTION
I was thinking of something like this in https://github.com/ungoogled-software/ungoogled-chromium-windows/issues/158#issuecomment-1172274425

Issues should look like this: https://github.com/PF4Public/ungoogled-chromium/issues/22

Android was omitted as currently not very active.

TODO-list before merging:

- [x] Change the if condition 
- [x] Squash everything