### PR TITLE
CI: Notify @ungoogled-software/notify-* platform teams for new versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md
+++ b/.github/ISSUE_TEMPLATE/create-an--updating-to-chromium-x-x-x-x-.md
@@ -14,3 +14,5 @@ If you are willing to work on updating the patches and lists, please leave a com
 If you'd like to increase visibility of your progress or get early feedback/advice, consider creating a [Draft Pull Request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests#draft-pull-requests). Finally, make sure to reference this issue in your PR. Please make sure to read [/docs/developing.md](https://github.com/ungoogled-software/ungoogled-chromium/blob/master/docs/developing.md#updating-patches) for guidance.
 
 Feel free to raise issues or questions throughout the process here. However, please refrain from asking for ETAs unless no visible progress has been made here or in the developer's PR for a while (e.g. 2 weeks).
+
+{{ env.NOTIFY_TEAMS }}

--- a/.github/workflows/new_version_check.yml
+++ b/.github/workflows/new_version_check.yml
@@ -6,7 +6,7 @@ on:
   # running every 6 hours
   schedule:
     - cron: '48 */6 * * *'
-  
+
 jobs:
   check:
     # do not run in forks
@@ -29,6 +29,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.latest-version.outputs.linux_version }}
           PLATFORM: all platforms
+          NOTIFY_TEAMS: "@ungoogled-software/notify-linux @ungoogled-software/notify-windows @ungoogled-software/notify-macos"
         with:
           update_existing: false
           search_existing: all
@@ -42,6 +43,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.latest-version.outputs.linux_version }}
           PLATFORM: Linux
+          NOTIFY_TEAMS: "@ungoogled-software/notify-linux"
         with:
           update_existing: false
           search_existing: all
@@ -55,6 +57,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.latest-version.outputs.mac_version }}
           PLATFORM: macOS
+          NOTIFY_TEAMS: "@ungoogled-software/notify-macos"
         with:
           update_existing: false
           search_existing: all
@@ -68,6 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ steps.latest-version.outputs.win_version }}
           PLATFORM: Windows
+          NOTIFY_TEAMS: "@ungoogled-software/notify-windows"
         with:
           update_existing: false
           search_existing: all


### PR DESCRIPTION
This pull request makes the github actions bot mention every relevant platform team if a new version gets released for a given platform. This does not reuse existing teams so that maintainance discussions and notifications are separate opt ins.
