### PR TITLE
Add flag for disabling link and text dragging

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -1,7 +1,7 @@
 # List of flags and switches
 
-This is an exhaustive list of command-line switches and flags introduced by ungoogled-chromium.  
-Each switch has a corresponding entry on the `chrome://flags` page which can be filtered by searching for `ungoogled-chromium`.  
+This is an exhaustive list of command-line switches and flags introduced by ungoogled-chromium.
+Each switch has a corresponding entry on the `chrome://flags` page which can be filtered by searching for `ungoogled-chromium`.
 
 If a switch requires a value, you must specify it with an `=` sign; e.g. flag `--foo` with value `bar` should be written as `--foo=bar`.
 
@@ -18,14 +18,14 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--fingerprinting-canvas-image-data-noise` | (Added flag to Bromite feature) Implements fingerprinting deception for Canvas image data retrieved via JS APIs. In the data, at most 10 pixels are slightly modified.
   `--fingerprinting-canvas-measuretext-noise` | (Added flag to Bromite feature) Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.
   `--fingerprinting-client-rects-noise` | (Added flag to Bromite feature) Implements fingerprinting deception of JS APIs `getClientRects()` and `getBoundingClientRect()` by scaling their output values with a random factor in the range -0.0003% to 0.0003%, which are recomputed for every document instantiation.
+  `--force-punycode-hostnames` | Convert all Internationalized Domain Names to punycode (ASCII representation of Unicode). See https://github.com/ungoogled-software/ungoogled-chromium/issues/370 for more details.
   `--hide-crashed-bubble` | Hides the bubble box with the message "Restore Pages? Chromium didn't shut down correctly." that shows on startup after the browser did not exit cleanly.
   `--http-accept-header` | Changes the default value of the `Accept` HTTP header sent with HTTP requests. Combined with `--disable-grease-tls` allows browser to look more like a tor-browser. See https://github.com/ungoogled-software/ungoogled-chromium/issues/783 for more details.
   `--keep-old-history` | Disables deletion of local browser history after 90 days
   `--max-connections-per-host` | (from Bromite) Configure the maximum allowed connections per host. Valid values are `6` and `15`
-  `--omnibox-autocomplete-filtering` | Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages.  Accepts `search`, `search-bookmarks`, `search-chrome`, and `search-bookmarks-chrome`.
+  `--omnibox-autocomplete-filtering` | Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages. Accepts `search`, `search-bookmarks`, `search-chrome`, and `search-bookmarks-chrome`.
   `--popups-to-tabs` | Makes popups open in new tabs.
   `--referrer-directive` | Allows setting a custom directive for referrer headers. Accepts `nocrossorigin`, `minimal`, and `noreferrers`. The no cross-origin referrer option removes all cross-origin referrers, the minimal option removes all cross-origin referrers and strips same-origin referrers down to the origin, and the no referrers option removes all referrers.
-  `--force-punycode-hostnames` | Convert all Internationalized Domain Names to punycode (ASCII representation of Unicode). See https://github.com/ungoogled-software/ungoogled-chromium/issues/370 for more details.
 
 - ### Available only on desktop
 
@@ -33,8 +33,8 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   -- | --
   `--bookmark-bar-ntp` | Sets the visibility of the bookmark bar on the New Tab Page. Only takes the value `never`.
   `--close-confirmation` | Show a warning prompt when closing the browser window. Accepts `last` (prompt when closing the last window with several tabs) and `multiple` (prompt only if more than one window is open). 
-  `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed.  Only takes the value `never`.
-  `--custom-ntp` | Allows setting a custom URL for the new tab page.  Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  This applies for incognito windows as well when not set to a `chrome://` internal page.
+  `--close-window-with-last-tab` | Determines whether a window should close once the last tab is closed. Only takes the value `never`.
+  `--custom-ntp` | Allows setting a custom URL for the new tab page. Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`). This applies for incognito windows as well when not set to a `chrome://` internal page.
   `--disable-sharing-hub` | Disables the sharing hub button.
   `--hide-sidepanel-button` | Hides the SidePanel Button.
   `--hide-tab-close-buttons` | Hides the close buttons on tabs.
@@ -54,8 +54,8 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
 
 ## Feature flags
 
-Feature flags are similar to switches with the difference being that they are passed as values for the `--enable-features` switch.  Multiple features can be passed at the same time by separating them with a comma, e.g. `--enable-features=flag1,flag2,flag3`.  
-These are also available on the `chrome://flags` page.  
+Feature flags are similar to switches with the difference being that they are passed as values for the `--enable-features` switch. Multiple features can be passed at the same time by separating them with a comma, e.g. `--enable-features=flag1,flag2,flag3`.
+These are also available on the `chrome://flags` page.
 
 - ### Available on all platforms
 

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -68,4 +68,5 @@ These are also available on the `chrome://flags` page.
   Feature | Description
   -- | --
   `ClearDataOnExit` | Clears all browsing data on exit.
+  `DisableLinkDrag` | Prevents dragging of links and selected text. Allows selecting text from a middle of a link. Also allows starting selection without first clearing the existing one. This behaviour is similar to the one from older Opera. See https://github.com/ungoogled-software/ungoogled-chromium/pull/2080 and https://github.com/ungoogled-software/ungoogled-chromium/discussions/2055 for more information.
   `DisableQRGenerator` | Disables the QR generator for sharing page links.

--- a/patches/extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
+++ b/patches/extra/bromite/fingerprinting-flags-client-rects-and-measuretext.patch
@@ -35,11 +35,11 @@
  #define CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
 +    {"fingerprinting-client-rects-noise",
 +     "Enable get*ClientRects() fingerprint deception",
-+     "Scale the output values of Range::getClientRects() and Element::getBoundingClientRect() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.  ungoogled-chromium flag, Bromite feature.",
++     "Scale the output values of Range::getClientRects() and Element::getBoundingClientRect() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization. ungoogled-chromium flag, Bromite feature.",
 +     kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingClientRectsNoise)},
 +    {"fingerprinting-canvas-measuretext-noise",
 +     "Enable Canvas::measureText() fingerprint deception",
-+     "Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.  ungoogled-chromium flag, Bromite feature.",
++     "Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization. ungoogled-chromium flag, Bromite feature.",
 +     kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingCanvasMeasureTextNoise)},
  #endif  // CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
 --- a/content/browser/BUILD.gn

--- a/patches/extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch
+++ b/patches/extra/bromite/flag-fingerprinting-canvas-image-data-noise.patch
@@ -29,7 +29,7 @@ approach to change color components.
       kOsAll, MULTI_VALUE_TYPE(kMaxConnectionsPerHostChoices)},
 +    {"fingerprinting-canvas-image-data-noise",
 +     "Enable Canvas image data fingerprint deception",
-+     "Slightly modifies at most 10 pixels in Canvas image data extracted via JS APIs.  ungoogled-chromium flag, Bromite feature.",
++     "Slightly modifies at most 10 pixels in Canvas image data extracted via JS APIs. ungoogled-chromium flag, Bromite feature.",
 +     kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingCanvasImageDataNoise)},
  #endif  // CHROME_BROWSER_BROMITE_FLAG_ENTRIES_H_
 --- a/content/browser/renderer_host/render_process_host_impl.cc

--- a/patches/extra/bromite/flag-max-connections-per-host.patch
+++ b/patches/extra/bromite/flag-max-connections-per-host.patch
@@ -40,7 +40,7 @@ with limited CPU/memory resources and it is disabled by default.
 +++ b/chrome/browser/bromite_flag_entries.h
 @@ -12,4 +12,8 @@
       "Enable Canvas::measureText() fingerprint deception",
-      "Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.  ungoogled-chromium flag, Bromite feature.",
+      "Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization. ungoogled-chromium flag, Bromite feature.",
       kOsAll, SINGLE_VALUE_TYPE(switches::kFingerprintingCanvasMeasureTextNoise)},
 +    {"max-connections-per-host",
 +     flag_descriptions::kMaxConnectionsPerHostName,
@@ -105,7 +105,7 @@ with limited CPU/memory resources and it is disabled by default.
  
 +const char kMaxConnectionsPerHostName[] = "Maximum connections per host";
 +const char kMaxConnectionsPerHostDescription[] =
-+     "Customize maximum allowed connections per host.  ungoogled-chromium flag, Bromite feature.";
++     "Customize maximum allowed connections per host. ungoogled-chromium flag, Bromite feature.";
 +
  const char kMediaRouterCastAllowAllIPsName[] =
      "Connect to Cast devices on all IP addresses";

--- a/patches/extra/ungoogled-chromium/add-flag-for-bookmark-bar-ntp.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-bookmark-bar-ntp.patch
@@ -39,10 +39,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -36,4 +36,8 @@
       "Scroll switches tab",
-      "Switch to the left/right tab if the wheel-scroll happens over the tabstrip, or the empty space beside the tabstrip.  ungoogled-chromium flag.",
+      "Switch to the left/right tab if the wheel-scroll happens over the tabstrip, or the empty space beside the tabstrip. ungoogled-chromium flag.",
       kOsDesktop, MULTI_VALUE_TYPE(kScrollEventChangesTab)},
 +    {"bookmark-bar-ntp",
 +     "Bookmark Bar on New-Tab-Page",
-+     "Disable the Bookmark Bar on the New-Tab-Page.  ungoogled-chromium flag.",
++     "Disable the Bookmark Bar on the New-Tab-Page. ungoogled-chromium flag.",
 +     kOsDesktop, MULTI_VALUE_TYPE(kBookmarkBarNewTab)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
@@ -176,10 +176,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -72,4 +72,8 @@
       "Remove Grab Handle",
-      "Removes the reserved empty space in the tabstrip for moving the window.  ungoogled-chromium flag",
+      "Removes the reserved empty space in the tabstrip for moving the window. ungoogled-chromium flag",
       kOsDesktop, SINGLE_VALUE_TYPE("remove-grab-handle")},
 +    {"close-confirmation",
 +     "Close Confirmation",
-+     "Show a warning prompt when closing the browser window.  ungoogled-chromium flag",
++     "Show a warning prompt when closing the browser window. ungoogled-chromium flag",
 +     kOsDesktop, MULTI_VALUE_TYPE(kCloseConfirmation)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-for-custom-ntp.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-custom-ntp.patch
@@ -19,11 +19,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -76,4 +76,8 @@
       "Close Confirmation",
-      "Show a warning prompt when closing the browser window.  ungoogled-chromium flag",
+      "Show a warning prompt when closing the browser window. ungoogled-chromium flag",
       kOsDesktop, MULTI_VALUE_TYPE(kCloseConfirmation)},
 +    {"custom-ntp",
 +     "Custom New Tab Page",
-+     "Allows setting a custom URL for the new tab page.  Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  This applies for incognito windows as well when not set to a `chrome://` internal page.  ungoogled-chromium flag",
++     "Allows setting a custom URL for the new tab page. Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`). This applies for incognito windows as well when not set to a `chrome://` internal page. ungoogled-chromium flag",
 +     kOsDesktop, ORIGIN_LIST_VALUE_TYPE("custom-ntp", "")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/flags_ui/flags_state.cc

--- a/patches/extra/ungoogled-chromium/add-flag-for-disabling-link-drag.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-disabling-link-drag.patch
@@ -1,0 +1,67 @@
+--- a/third_party/blink/common/features.cc
++++ b/third_party/blink/common/features.cc
+@@ -14,6 +14,8 @@
+ 
+ namespace blink {
+ namespace features {
++
++const base::Feature kDisableLinkDrag{"DisableLinkDrag", base::FEATURE_DISABLED_BY_DEFAULT};
+ 
+ // Apply lazy-loading to ad frames which have embeds likely impacting Core Web
+ // Vitals.
+--- a/third_party/blink/public/common/features.h
++++ b/third_party/blink/public/common/features.h
+@@ -16,6 +16,8 @@
+ 
+ namespace blink {
+ namespace features {
++
++BLINK_COMMON_EXPORT extern const base::Feature kDisableLinkDrag;
+ 
+ BLINK_COMMON_EXPORT extern const base::Feature kAutomaticLazyFrameLoadingToAds;
+ BLINK_COMMON_EXPORT extern const base::Feature
+--- a/third_party/blink/renderer/core/input/mouse_event_manager.cc
++++ b/third_party/blink/renderer/core/input/mouse_event_manager.cc
+@@ -687,8 +687,14 @@
+ 
+   bool single_click = event.Event().click_count <= 1;
+ 
++if (base::FeatureList::IsEnabled(features::kDisableLinkDrag)){
++  mouse_down_may_start_drag_ = single_click && !IsSelectionOverLink(event) &&
++                               !IsExtendingSelection(event) &&
++			        !event.GetHitTestResult().IsSelected(event.GetHitTestLocation());
++}else{
+   mouse_down_may_start_drag_ = single_click && !IsSelectionOverLink(event) &&
+                                !IsExtendingSelection(event);
++}
+ 
+   mouse_down_ = event.Event();
+ 
+--- a/third_party/blink/renderer/core/editing/selection_controller.cc
++++ b/third_party/blink/renderer/core/editing/selection_controller.cc
+@@ -1319,9 +1319,13 @@
+ }
+ 
+ bool IsSelectionOverLink(const MouseEventWithHitTestResults& event) {
++if (base::FeatureList::IsEnabled(features::kDisableLinkDrag)){
++  return event.IsOverLink();
++}else{
+   return (event.Event().GetModifiers() & WebInputEvent::Modifiers::kAltKey) !=
+              0 &&
+          event.IsOverLink();
++}
+ }
+ 
+ bool IsUserNodeDraggable(const MouseEventWithHitTestResults& event) {
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -108,4 +108,8 @@
+      "Hide SidePanel Button",
+      "Hides the SidePanel Button.  ungoogled-chromium flag.",
+      kOsDesktop, SINGLE_VALUE_TYPE("hide-sidepanel-button")},
++    {"disable-link-drag",
++     "Disable link drag",
++     "Prevents dragging of links and selected text.  ungoogled-chromium flag.",
++     kOsDesktop, FEATURE_VALUE_TYPE(blink::features::kDisableLinkDrag)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+

--- a/patches/extra/ungoogled-chromium/add-flag-for-disabling-link-drag.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-disabling-link-drag.patch
@@ -57,11 +57,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -108,4 +108,8 @@
       "Hide SidePanel Button",
-      "Hides the SidePanel Button.  ungoogled-chromium flag.",
+      "Hides the SidePanel Button. ungoogled-chromium flag.",
       kOsDesktop, SINGLE_VALUE_TYPE("hide-sidepanel-button")},
 +    {"disable-link-drag",
 +     "Disable link drag",
-+     "Prevents dragging of links and selected text.  ungoogled-chromium flag.",
++     "Prevents dragging of links and selected text. ungoogled-chromium flag.",
 +     kOsDesktop, FEATURE_VALUE_TYPE(blink::features::kDisableLinkDrag)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 

--- a/patches/extra/ungoogled-chromium/add-flag-for-grab-handle.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-grab-handle.patch
@@ -12,10 +12,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -68,4 +68,8 @@
       "Disable QR Generator",
-      "Disables the QR generator for sharing page links.  ungoogled-chromium flag",
+      "Disables the QR generator for sharing page links. ungoogled-chromium flag",
       kOsDesktop, FEATURE_VALUE_TYPE(kDisableQRGenerator)},
 +    {"remove-grab-handle",
 +     "Remove Grab Handle",
-+     "Removes the reserved empty space in the tabstrip for moving the window.  ungoogled-chromium flag",
++     "Removes the reserved empty space in the tabstrip for moving the window. ungoogled-chromium flag",
 +     kOsDesktop, SINGLE_VALUE_TYPE("remove-grab-handle")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
@@ -24,11 +24,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -40,4 +40,8 @@
       "Bookmark Bar on New-Tab-Page",
-      "Disable the Bookmark Bar on the New-Tab-Page.  ungoogled-chromium flag.",
+      "Disable the Bookmark Bar on the New-Tab-Page. ungoogled-chromium flag.",
       kOsDesktop, MULTI_VALUE_TYPE(kBookmarkBarNewTab)},
 +    {"omnibox-autocomplete-filtering",
 +     "Omnibox Autocomplete Filtering",
-+     "Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages.  ungoogled-chromium flag.",
++     "Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages. ungoogled-chromium flag.",
 +     kOsAll, MULTI_VALUE_TYPE(kOmniboxAutocompleteFiltering)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/omnibox/browser/autocomplete_controller.cc

--- a/patches/extra/ungoogled-chromium/add-flag-for-qr-generator.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-qr-generator.patch
@@ -41,10 +41,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -64,4 +64,8 @@
       "Remove Tabsearch Button",
-      "Removes the tabsearch button from the tabstrip.  ungoogled-chromium flag",
+      "Removes the tabsearch button from the tabstrip. ungoogled-chromium flag",
       kOsDesktop, SINGLE_VALUE_TYPE("remove-tabsearch-button")},
 +    {"disable-qr-generator",
 +     "Disable QR Generator",
-+     "Disables the QR generator for sharing page links.  ungoogled-chromium flag",
++     "Disables the QR generator for sharing page links. ungoogled-chromium flag",
 +     kOsDesktop, FEATURE_VALUE_TYPE(kDisableQRGenerator)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-for-referrer-header.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-referrer-header.patch
@@ -21,11 +21,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -88,4 +88,8 @@
       "Hide tab close buttons",
-      "Hides the close buttons on tabs.  ungoogled-chromium flag.",
+      "Hides the close buttons on tabs. ungoogled-chromium flag.",
       kOsDesktop, SINGLE_VALUE_TYPE("hide-tab-close-buttons")},
 +    {"referrer-directive",
 +     "Referrer directive",
-+     "Allows setting a custom directive for referrer headers.  The no cross-origin referrer option removes all cross-origin referrers, the minimal option removes all cross-origin referrers and strips same-origin referrers down to the origin, and the no referrers option removes all referrers.  ungoogled-chromium flag.",
++     "Allows setting a custom directive for referrer headers. The no cross-origin referrer option removes all cross-origin referrers, the minimal option removes all cross-origin referrers and strips same-origin referrers down to the origin, and the no referrers option removes all referrers. ungoogled-chromium flag.",
 +     kOsAll, MULTI_VALUE_TYPE(kReferrerDirective)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/content/browser/utility_process_host.cc

--- a/patches/extra/ungoogled-chromium/add-flag-for-search-engine-collection.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-search-engine-collection.patch
@@ -4,11 +4,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -12,4 +12,8 @@
       "Handling of extension MIME type requests",
-      "Used when deciding how to handle a request for a CRX or User Script MIME type.  ungoogled-chromium flag.",
+      "Used when deciding how to handle a request for a CRX or User Script MIME type. ungoogled-chromium flag.",
       kOsAll, MULTI_VALUE_TYPE(kExtensionHandlingChoices)},
 +    {"disable-search-engine-collection",
 +     "Disable search engine collection",
-+     "Prevents search engines from being added automatically.  ungoogled-chromium flag.",
++     "Prevents search engines from being added automatically. ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("disable-search-engine-collection")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/chrome/renderer/chrome_render_frame_observer.cc

--- a/patches/extra/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-tab-hover-cards.patch
@@ -56,10 +56,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -80,4 +80,8 @@
       "Custom New Tab Page",
-      "Allows setting a custom URL for the new tab page.  Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`).  This applies for incognito windows as well when not set to a `chrome://` internal page.  ungoogled-chromium flag",
+      "Allows setting a custom URL for the new tab page. Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`). This applies for incognito windows as well when not set to a `chrome://` internal page. ungoogled-chromium flag",
       kOsDesktop, ORIGIN_LIST_VALUE_TYPE("custom-ntp", "")},
 +    {"tab-hover-cards",
 +     "Tab Hover Cards",
-+     "Allows removing the tab hover cards or using a tooltip as a replacement.  ungoogled-chromium flag.",
++     "Allows removing the tab hover cards or using a tooltip as a replacement. ungoogled-chromium flag.",
 +     kOsDesktop, MULTI_VALUE_TYPE(kTabHoverCards)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-for-tabsearch-button.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-tabsearch-button.patch
@@ -34,10 +34,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -60,4 +60,8 @@
       "Clear data on exit",
-      "Clears all browsing data on exit.  ungoogled-chromium flag",
+      "Clears all browsing data on exit. ungoogled-chromium flag",
       kOsDesktop, FEATURE_VALUE_TYPE(browsing_data::features::kClearDataOnExit)},
 +    {"remove-tabsearch-button",
 +     "Remove Tabsearch Button",
-+     "Removes the tabsearch button from the tabstrip.  ungoogled-chromium flag",
++     "Removes the tabsearch button from the tabstrip. ungoogled-chromium flag",
 +     kOsDesktop, SINGLE_VALUE_TYPE("remove-tabsearch-button")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-change-http-accept-header.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-change-http-accept-header.patch
@@ -2,11 +2,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -96,4 +96,8 @@
       "Disable GREASE for TLS",
-      "Turn off GREASE (Generate Random Extensions And Sustain Extensibility) for TLS connections.  ungoogled-chromium flag.",
+      "Turn off GREASE (Generate Random Extensions And Sustain Extensibility) for TLS connections. ungoogled-chromium flag.",
       kOsAll, SINGLE_VALUE_TYPE("disable-grease-tls")},
 +    {"http-accept-header",
 +     "Custom HTTP Accept Header",
-+     "Set a custom value for the Accept header which is sent by the browser with every HTTP request.  (e.g. `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`).  ungoogled-chromium flag.",
++     "Set a custom value for the Accept header which is sent by the browser with every HTTP request.  (e.g. `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`). ungoogled-chromium flag.",
 +     kOsAll, ORIGIN_LIST_VALUE_TYPE("http-accept-header", "")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/flags_ui/flags_state.cc

--- a/patches/extra/ungoogled-chromium/add-flag-to-clear-data-on-exit.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-clear-data-on-exit.patch
@@ -68,11 +68,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -56,4 +56,8 @@
       "Keep old history",
-      "Keep history older than 3 months.  ungoogled-chromium flag",
+      "Keep history older than 3 months. ungoogled-chromium flag",
       kOsAll, SINGLE_VALUE_TYPE("keep-old-history")},
 +    {"clear-data-on-exit",
 +     "Clear data on exit",
-+     "Clears all browsing data on exit.  ungoogled-chromium flag",
++     "Clears all browsing data on exit. ungoogled-chromium flag",
 +     kOsDesktop, FEATURE_VALUE_TYPE(browsing_data::features::kClearDataOnExit)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/browsing_data/core/features.cc

--- a/patches/extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-close-window-with-last-tab.patch
@@ -36,10 +36,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -44,4 +44,8 @@
       "Omnibox Autocomplete Filtering",
-      "Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages.  ungoogled-chromium flag.",
+      "Restrict omnibox autocomplete results to a combination of search suggestions (if enabled), bookmarks, and internal chrome pages. ungoogled-chromium flag.",
       kOsAll, MULTI_VALUE_TYPE(kOmniboxAutocompleteFiltering)},
 +    {"close-window-with-last-tab",
 +     "Close window with last tab",
-+     "Determines whether a window should close once the last tab is closed.  ungoogled-chromium flag.",
++     "Determines whether a window should close once the last tab is closed. ungoogled-chromium flag.",
 +     kOsDesktop, MULTI_VALUE_TYPE(kCloseWindowWithLastTab)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-configure-extension-downloading.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-configure-extension-downloading.patch
@@ -111,10 +111,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -8,4 +8,8 @@
       "SetIpv6ProbeFalse",
-      "Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.  ungoogled-chromium flag.",
+      "Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible. ungoogled-chromium flag.",
       kOsAll, FEATURE_VALUE_TYPE(net::features::kSetIpv6ProbeFalse)},
 +    {"extension-mime-request-handling",
 +     "Handling of extension MIME type requests",
-+     "Used when deciding how to handle a request for a CRX or User Script MIME type.  ungoogled-chromium flag.",
++     "Used when deciding how to handle a request for a CRX or User Script MIME type. ungoogled-chromium flag.",
 +     kOsAll, MULTI_VALUE_TYPE(kExtensionHandlingChoices)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-convert-popups-to-tabs.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-convert-popups-to-tabs.patch
@@ -4,11 +4,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -48,4 +48,8 @@
       "Close window with last tab",
-      "Determines whether a window should close once the last tab is closed.  ungoogled-chromium flag.",
+      "Determines whether a window should close once the last tab is closed. ungoogled-chromium flag.",
       kOsDesktop, MULTI_VALUE_TYPE(kCloseWindowWithLastTab)},
 +    {"popups-to-tabs",
 +     "Popups to tabs",
-+     "Makes popups open in new tabs.  ungoogled-chromium flag",
++     "Makes popups open in new tabs. ungoogled-chromium flag",
 +     kOsAll, SINGLE_VALUE_TYPE("popups-to-tabs")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/content/renderer/render_view_impl.cc

--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-beforeunload.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-beforeunload.patch
@@ -4,11 +4,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -16,4 +16,8 @@
       "Disable search engine collection",
-      "Prevents search engines from being added automatically.  ungoogled-chromium flag.",
+      "Prevents search engines from being added automatically. ungoogled-chromium flag.",
       kOsAll, SINGLE_VALUE_TYPE("disable-search-engine-collection")},
 +    {"disable-beforeunload",
 +     "Disable beforeunload",
-+     "Disables JavaScript dialog boxes triggered by beforeunload.  ungoogled-chromium flag.",
++     "Disables JavaScript dialog boxes triggered by beforeunload. ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("disable-beforeunload")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/javascript_dialogs/app_modal_dialog_manager.cc

--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
@@ -4,11 +4,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -52,4 +52,8 @@
       "Popups to tabs",
-      "Makes popups open in new tabs.  ungoogled-chromium flag",
+      "Makes popups open in new tabs. ungoogled-chromium flag",
       kOsAll, SINGLE_VALUE_TYPE("popups-to-tabs")},
 +    {"keep-old-history",
 +     "Keep old history",
-+     "Keep history older than 3 months.  ungoogled-chromium flag",
++     "Keep history older than 3 months. ungoogled-chromium flag",
 +     kOsAll, SINGLE_VALUE_TYPE("keep-old-history")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/history/core/browser/history_backend.cc

--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-sharing-hub.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-sharing-hub.patch
@@ -20,10 +20,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -100,4 +100,8 @@
       "Custom HTTP Accept Header",
-      "Set a custom value for the Accept header which is sent by the browser with every HTTP request.  (e.g. `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`).  ungoogled-chromium flag.",
+      "Set a custom value for the Accept header which is sent by the browser with every HTTP request.  (e.g. `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`). ungoogled-chromium flag.",
       kOsAll, ORIGIN_LIST_VALUE_TYPE("http-accept-header", "")},
 +    {"disable-sharing-hub",
 +     "Disable Sharing Hub",
-+     "Disables the sharing hub button.  ungoogled-chromium flag.",
++     "Disables the sharing hub button. ungoogled-chromium flag.",
 +     kOsDesktop, SINGLE_VALUE_TYPE("disable-sharing-hub")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-tls-grease.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-tls-grease.patch
@@ -2,11 +2,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -92,4 +92,8 @@
       "Referrer directive",
-      "Allows setting a custom directive for referrer headers.  The no cross-origin referrer option removes all cross-origin referrers, the minimal option removes all cross-origin referrers and strips same-origin referrers down to the origin, and the no referrers option removes all referrers.  ungoogled-chromium flag.",
+      "Allows setting a custom directive for referrer headers. The no cross-origin referrer option removes all cross-origin referrers, the minimal option removes all cross-origin referrers and strips same-origin referrers down to the origin, and the no referrers option removes all referrers. ungoogled-chromium flag.",
       kOsAll, MULTI_VALUE_TYPE(kReferrerDirective)},
 +    {"disable-grease-tls",
 +     "Disable GREASE for TLS",
-+     "Turn off GREASE (Generate Random Extensions And Sustain Extensibility) for TLS connections.  ungoogled-chromium flag.",
++     "Turn off GREASE (Generate Random Extensions And Sustain Extensibility) for TLS connections. ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("disable-grease-tls")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/net/socket/ssl_client_socket_impl.cc

--- a/patches/extra/ungoogled-chromium/add-flag-to-force-punycode-hostnames.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-force-punycode-hostnames.patch
@@ -4,11 +4,11 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -20,4 +20,8 @@
       "Disable beforeunload",
-      "Disables JavaScript dialog boxes triggered by beforeunload.  ungoogled-chromium flag.",
+      "Disables JavaScript dialog boxes triggered by beforeunload. ungoogled-chromium flag.",
       kOsAll, SINGLE_VALUE_TYPE("disable-beforeunload")},
 +    {"force-punycode-hostnames",
 +     "Force punycode hostnames",
-+     "Force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs).  ungoogled-chromium flag.",
++     "Force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs). ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("force-punycode-hostnames")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/components/url_formatter/url_formatter.cc

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-crashed-bubble.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-crashed-bubble.patch
@@ -17,10 +17,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -28,4 +28,8 @@
       "Show avatar/people/profile button",
-      "Show avatar/people/profile button in the browser toolbar.  ungoogled-chromium flag.",
+      "Show avatar/people/profile button in the browser toolbar. ungoogled-chromium flag.",
       kOsDesktop, MULTI_VALUE_TYPE(kShowAvatarButtonChoices)},
 +    {"hide-crashed-bubble",
 +     "Hide crashed bubble",
-+     "Hides the bubble box with the message \"Restore Pages? Chromium didn't shut down correctly.\" that shows on startup after the browser did not exit cleanly.  ungoogled-chromium flag.",
++     "Hides the bubble box with the message \"Restore Pages? Chromium didn't shut down correctly.\" that shows on startup after the browser did not exit cleanly. ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("hide-crashed-bubble")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch
@@ -12,10 +12,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -104,4 +104,8 @@
       "Disable Sharing Hub",
-      "Disables the sharing hub button.  ungoogled-chromium flag.",
+      "Disables the sharing hub button. ungoogled-chromium flag.",
       kOsDesktop, SINGLE_VALUE_TYPE("disable-sharing-hub")},
 +    {"hide-sidepanel-button",
 +     "Hide SidePanel Button",
-+     "Hides the SidePanel Button.  ungoogled-chromium flag.",
++     "Hides the SidePanel Button. ungoogled-chromium flag.",
 +     kOsDesktop, SINGLE_VALUE_TYPE("hide-sidepanel-button")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-tab-close-buttons.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-tab-close-buttons.patch
@@ -25,10 +25,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -84,4 +84,8 @@
       "Tab Hover Cards",
-      "Allows removing the tab hover cards or using a tooltip as a replacement.  ungoogled-chromium flag.",
+      "Allows removing the tab hover cards or using a tooltip as a replacement. ungoogled-chromium flag.",
       kOsDesktop, MULTI_VALUE_TYPE(kTabHoverCards)},
 +    {"hide-tab-close-buttons",
 +     "Hide tab close buttons",
-+     "Hides the close buttons on tabs.  ungoogled-chromium flag.",
++     "Hides the close buttons on tabs. ungoogled-chromium flag.",
 +     kOsDesktop, SINGLE_VALUE_TYPE("hide-tab-close-buttons")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-scroll-tabs.patch
@@ -78,10 +78,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -32,4 +32,8 @@
       "Hide crashed bubble",
-      "Hides the bubble box with the message \"Restore Pages? Chromium didn't shut down correctly.\" that shows on startup after the browser did not exit cleanly.  ungoogled-chromium flag.",
+      "Hides the bubble box with the message \"Restore Pages? Chromium didn't shut down correctly.\" that shows on startup after the browser did not exit cleanly. ungoogled-chromium flag.",
       kOsAll, SINGLE_VALUE_TYPE("hide-crashed-bubble")},
 +    {"scroll-tabs",
 +     "Scroll switches tab",
-+     "Switch to the left/right tab if the wheel-scroll happens over the tabstrip, or the empty space beside the tabstrip.  ungoogled-chromium flag.",
++     "Switch to the left/right tab if the wheel-scroll happens over the tabstrip, or the empty space beside the tabstrip. ungoogled-chromium flag.",
 +     kOsDesktop, MULTI_VALUE_TYPE(kScrollEventChangesTab)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-show-avatar-button.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-show-avatar-button.patch
@@ -56,10 +56,10 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -24,4 +24,8 @@
       "Force punycode hostnames",
-      "Force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs).  ungoogled-chromium flag.",
+      "Force punycode in hostnames instead of Unicode when displaying Internationalized Domain Names (IDNs). ungoogled-chromium flag.",
       kOsAll, SINGLE_VALUE_TYPE("force-punycode-hostnames")},
 +    {"show-avatar-button",
 +     "Show avatar/people/profile button",
-+     "Show avatar/people/profile button in the browser toolbar.  ungoogled-chromium flag.",
++     "Show avatar/people/profile button in the browser toolbar. ungoogled-chromium flag.",
 +     kOsDesktop, MULTI_VALUE_TYPE(kShowAvatarButtonChoices)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-ipv6-probing-option.patch
+++ b/patches/extra/ungoogled-chromium/add-ipv6-probing-option.patch
@@ -8,7 +8,7 @@
  #define CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 +    {"set-ipv6-probe-false",
 +     "SetIpv6ProbeFalse",
-+     "Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.  ungoogled-chromium flag.",
++     "Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible. ungoogled-chromium flag.",
 +     kOsAll, FEATURE_VALUE_TYPE(net::features::kSetIpv6ProbeFalse)},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
 --- a/net/base/features.cc

--- a/patches/series
+++ b/patches/series
@@ -99,3 +99,4 @@ extra/ungoogled-chromium/add-flag-to-disable-tls-grease.patch
 extra/ungoogled-chromium/add-flag-to-change-http-accept-header.patch
 extra/ungoogled-chromium/add-flag-to-disable-sharing-hub.patch
 extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch
+extra/ungoogled-chromium/add-flag-for-disabling-link-drag.patch


### PR DESCRIPTION
Implementation of https://github.com/ungoogled-software/ungoogled-chromium/discussions/2055#discussioncomment-3494020 through feature flag thanks to help from @Ahrotahn and @networkException.

This allows selecting text from within a link and also allows starting the selection without clearing the existing one.
[This is a long link, that I'll use for demonstration of what it is. They say a <s>picture</s> video is worth a thousand words](https://github.com/ungoogled-software/ungoogled-chromium/).
And here is some more text for demonstration purposes only :)

With the flag enabled following becomes possible:

https://user-images.githubusercontent.com/10319700/188681263-9bc37892-a980-4cf9-ac66-7f199f43a325.mp4


PS: I also reordered `--force-punycode-hostnames` to be in alphabetical order.