### PR TITLE
feat: add --enable-persistent-cookies switch

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -14,6 +14,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--disable-beforeunload` | Disables JavaScript dialog boxes triggered by `beforeunload`
   `--disable-grease-tls` | Disables GREASE for TLS. Combined with `--http-accept-header` allows browser to look more like a tor-browser. See https://github.com/ungoogled-software/ungoogled-chromium/issues/783 for more details.
   `--disable-search-engine-collection` | Disable automatic search engine scraping from webpages.
+  `--enable-persistent-cookies` | Enables cookies to be persisted between sessions (by default cookies are session-only.)
   `--extension-mime-request-handling` | Change how extension MIME types (CRX and user scripts) are handled. Acceptable values are `download-as-regular-file` or `always-prompt-for-install`. Leave unset to use normal behavior.
   `--fingerprinting-canvas-image-data-noise` | (Added flag to Bromite feature) Implements fingerprinting deception for Canvas image data retrieved via JS APIs. In the data, at most 10 pixels are slightly modified.
   `--fingerprinting-canvas-measuretext-noise` | (Added flag to Bromite feature) Scale the output values of Canvas::measureText() with a randomly selected factor in the range -0.0003% to 0.0003%, which are recomputed on every document initialization.

--- a/patches/extra/iridium-browser/prefs-only-keep-cookies-until-exit.patch
+++ b/patches/extra/iridium-browser/prefs-only-keep-cookies-until-exit.patch
@@ -15,7 +15,7 @@ Out with all those tracking cookies!
    // DefaultProvider::DiscardOrMigrateObsoletePreferences() accordingly.
  
 -  Register(ContentSettingsType::COOKIES, "cookies", CONTENT_SETTING_ALLOW,
-+  Register(ContentSettingsType::COOKIES, "cookies", CONTENT_SETTING_SESSION_ONLY,
++  Register(ContentSettingsType::COOKIES, "cookies", base::CommandLine::ForCurrentProcess()->HasSwitch("enable-persistent-cookies") ? CONTENT_SETTING_ALLOW : CONTENT_SETTING_SESSION_ONLY,
             WebsiteSettingsInfo::SYNCABLE,
             AllowlistedSchemes(kChromeUIScheme, kChromeDevToolsScheme),
             ValidSettings(CONTENT_SETTING_ALLOW, CONTENT_SETTING_BLOCK,


### PR DESCRIPTION
Since cookies default to session-only by default, when starting ungoogled-chromium in kiosk-mode it's impossible to persist cookie state without a lot of hassle with settings files. This PR adds a switch, `--enable-persistent-cookies`, that simply makes cookies persist across sessions.

(For context, I'm trying to display a web app in Chromium kiosk-mode. The problem is that the web app has logins, which due to the cookie setting don't get persisted across multiple sessions, meaning every time the Chromium instance is launched the web app has to be logged into again. This forces me to use normal Chromium, but it would be great if I could use ungoogled-chromium for this usecase.)