### PR TITLE
Add flag for hiding the fullscreen exit UI

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -37,6 +37,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--custom-ntp` | Allows setting a custom URL for the new tab page. Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`). This applies for incognito windows as well when not set to a `chrome://` internal page.
   `--disable-sharing-hub` | Disables the sharing hub button.
   `--hide-extensions-menu` | Hides the extensions menu (the puzzle piece icon).
+  `--hide-fullscreen-exit-ui` | Hides the "X" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode.
   `--hide-sidepanel-button` | Hides the SidePanel Button.
   `--hide-tab-close-buttons` | Hides the close buttons on tabs.
   `--remove-grab-handle` | Removes the reserved empty space in the tabstrip for moving the window.

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
@@ -1,3 +1,16 @@
+--- a/chrome/browser/ui/views/frame/browser_view.cc
++++ b/chrome/browser/ui/views/frame/browser_view.cc
+@@ -1828,6 +1828,10 @@
+     ExclusiveAccessBubbleHideCallback bubble_first_hide_callback,
+     bool notify_download,
+     bool force_update) {
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
++          "hide-fullscreen-exit-ui"))
++    return;
++
+   DCHECK(!notify_download || exclusive_access_bubble_);
+   // Trusted pinned mode does not allow to escape. So do not show the bubble.
+   bool is_trusted_pinned =
 --- a/chrome/browser/ui/views/fullscreen_control/fullscreen_control_host.cc
 +++ b/chrome/browser/ui/views/fullscreen_control/fullscreen_control_host.cc
 @@ -69,6 +69,10 @@ bool IsExitUiEnabled() {
@@ -19,6 +32,6 @@
       kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
 +    {"hide-fullscreen-exit-ui",
 +     "Hide Fullscreen Exit UI",
-+     "Hides the \"X\" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode. ungoogled-chromium flag.",
-+     kOsLinux | kOsWindows, SINGLE_VALUE_TYPE("hide-fullscreen-exit-ui")},
++     "Hides the \"X\" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode. Additionally, this hides the \"Press F11 to exit full screen\" popup. ungoogled-chromium flag.",
++     kOsLinux | kOsWin, SINGLE_VALUE_TYPE("hide-fullscreen-exit-ui")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
@@ -1,0 +1,24 @@
+--- a/chrome/browser/ui/views/fullscreen_control/fullscreen_control_host.cc
++++ b/chrome/browser/ui/views/fullscreen_control/fullscreen_control_host.cc
+@@ -69,6 +69,10 @@ bool IsExitUiEnabled() {
+   // menu and controls reveal when the cursor is moved to the top.
+   return false;
+ #else
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
++          "hide-fullscreen-exit-ui"))
++    return false;
++
+   // Kiosk mode is a fullscreen experience, which makes the exit UI
+   // inappropriate.
+   return !chrome::IsRunningInAppMode();
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -116,4 +116,8 @@
+      "Hide Extensions Menu",
+      "Hides the extensions menu (the puzzle piece icon). ungoogled-chromium flag.",
+      kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
++    {"hide-fullscreen-exit-ui",
++     "Hide Fullscreen Exit UI",
++     "Hides the \"X\" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode. ungoogled-chromium flag.",
++     kOsLinux | kOsWindows, SINGLE_VALUE_TYPE("hide-fullscreen-exit-ui")},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/series
+++ b/patches/series
@@ -101,3 +101,4 @@ extra/ungoogled-chromium/add-flag-to-disable-sharing-hub.patch
 extra/ungoogled-chromium/add-flag-to-hide-side-panel-button.patch
 extra/ungoogled-chromium/add-flag-for-disabling-link-drag.patch
 extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
+extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch


### PR DESCRIPTION
This adds a flag that hides the "X" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode. This is very similar to the now removed `enable-experimental-fullscreen-exit-ui` flag.
