### PR TITLE
Update documentation for hide-extensions-menu and hide-fullscreen-exit-ui flags

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -38,7 +38,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--disable-sharing-hub` | Disables the sharing hub button.
   `--enable-incognito-themes` | Allows themes to change the appearance of Incognito windows.
   `--hide-extensions-menu` | Hides the extensions container. This includes the puzzle piece icon as well as any pinned extensions.
-  `--hide-fullscreen-exit-ui` | Hides the "X" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode.
+  `--hide-fullscreen-exit-ui` | Hides the "X" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode. Additionally, this hides the "Press F11 to exit full screen" popup.
   `--hide-sidepanel-button` | Hides the SidePanel Button.
   `--hide-tab-close-buttons` | Hides the close buttons on tabs.
   `--remove-grab-handle` | Removes the reserved empty space in the tabstrip for moving the window.

--- a/docs/flags.md
+++ b/docs/flags.md
@@ -37,7 +37,7 @@ If a switch requires a value, you must specify it with an `=` sign; e.g. flag `-
   `--custom-ntp` | Allows setting a custom URL for the new tab page. Value can be internal (e.g. `about:blank`), external (e.g. `example.com`), or local (e.g. `file:///tmp/startpage.html`). This applies for incognito windows as well when not set to a `chrome://` internal page.
   `--disable-sharing-hub` | Disables the sharing hub button.
   `--enable-incognito-themes` | Allows themes to change the appearance of Incognito windows.
-  `--hide-extensions-menu` | Hides the extensions menu (the puzzle piece icon).
+  `--hide-extensions-menu` | Hides the extensions container. This includes the puzzle piece icon as well as any pinned extensions.
   `--hide-fullscreen-exit-ui` | Hides the "X" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode.
   `--hide-sidepanel-button` | Hides the SidePanel Button.
   `--hide-tab-close-buttons` | Hides the close buttons on tabs.

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
@@ -52,6 +52,6 @@
       kOsDesktop, FEATURE_VALUE_TYPE(blink::features::kDisableLinkDrag)},
 +    {"hide-extensions-menu",
 +     "Hide Extensions Menu",
-+     "Hides the extensions menu (the puzzle piece icon). ungoogled-chromium flag.",
++     "Hides the extensions container. This includes the puzzle piece icon as well as any pinned extensions. ungoogled-chromium flag.",
 +     kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
@@ -28,7 +28,7 @@
 +++ b/chrome/browser/ungoogled_flag_entries.h
 @@ -116,4 +116,8 @@
       "Hide Extensions Menu",
-      "Hides the extensions menu (the puzzle piece icon). ungoogled-chromium flag.",
+      "Hides the extensions container. This includes the puzzle piece icon as well as any pinned extensions. ungoogled-chromium flag.",
       kOsDesktop, SINGLE_VALUE_TYPE("hide-extensions-menu")},
 +    {"hide-fullscreen-exit-ui",
 +     "Hide Fullscreen Exit UI",


### PR DESCRIPTION
This PR updates the documentation for the hide-extensions-menu and hide-fullscreen-exit-ui flags.  

There was some discussion in #2005 that the verbiage could be clarified, so that has been updated to be more clear.  
In #2176 the flag gained extra functionality.  Its description was updated but docs/flags.md didn't include the new change.  