### PR TITLE
Get rid of "mailto:" when copying email address

### DIFF
--- a/patches/extra/ungoogled-chromium/disable-formatting-in-omnibox.patch
+++ b/patches/extra/ungoogled-chromium/disable-formatting-in-omnibox.patch
@@ -1,4 +1,6 @@
 # Disables omission of URL elements in Omnibox
+# except for the mailto scheme so that email links can be properly 
+# formatted when copied to clipboard (#2225). 
 
 --- a/components/url_formatter/url_formatter.cc
 +++ b/components/url_formatter/url_formatter.cc
@@ -13,8 +15,6 @@
 -const FormatUrlType kFormatUrlOmitTrivialSubdomains = 1 << 5;
 -const FormatUrlType kFormatUrlTrimAfterHost = 1 << 6;
 -const FormatUrlType kFormatUrlOmitFileScheme = 1 << 7;
--const FormatUrlType kFormatUrlOmitMailToScheme = 1 << 8;
--const FormatUrlType kFormatUrlOmitMobilePrefix = 1 << 9;
 +const FormatUrlType kFormatUrlOmitUsernamePassword = 0 << 0;
 +const FormatUrlType kFormatUrlOmitHTTP = 0 << 1;
 +const FormatUrlType kFormatUrlOmitTrailingSlashOnBareHostname = 0 << 2;
@@ -22,7 +22,8 @@
 +const FormatUrlType kFormatUrlOmitTrivialSubdomains = 0 << 5;
 +const FormatUrlType kFormatUrlTrimAfterHost = 0 << 6;
 +const FormatUrlType kFormatUrlOmitFileScheme = 0 << 7;
-+const FormatUrlType kFormatUrlOmitMailToScheme = 0 << 8;
+ const FormatUrlType kFormatUrlOmitMailToScheme = 1 << 8;
+-const FormatUrlType kFormatUrlOmitMobilePrefix = 1 << 9;
 +const FormatUrlType kFormatUrlOmitMobilePrefix = 0 << 9;
  
  const FormatUrlType kFormatUrlOmitDefaults =


### PR DESCRIPTION
When copying an email address in vanilla Chromium, the `mailto:` prefix is removed and only the email address is copied. However, `disable-formatting-in-omnibox.patch` disables `kFormatUrlOmitMailToScheme`, so the email link won't be formatted when copied to the clipboard, and the copied email address `someone@example.com` becomes `mailto:someone@example.com`. 

This PR re-enables `kFormatUrlOmitMailToScheme` field. 

Fixes #2224