### PR TITLE
.cirrus: bump python to 3.11 slim from 3.6 slim

### DIFF
--- a/.cirrus_Dockerfile
+++ b/.cirrus_Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Python 3 with xz-utils (for tar.xz unpacking)
 
-FROM python:3.6-slim
+FROM python:3.11-slim
 
 RUN apt update && apt install -y xz-utils patch axel

--- a/.cirrus_requirements.txt
+++ b/.cirrus_requirements.txt
@@ -1,7 +1,7 @@
 # Based on Python package versions in Debian buster
-astroid==2.1.0 # via pylint
-pylint==2.2.2
-pytest-cov==2.6.0
-pytest==3.10.1
-requests==2.21.0
-yapf==0.25.0
+astroid==2.13.3 # via pylint
+pylint==2.15.10
+pytest-cov==4.0.0
+pytest==7.2.1
+requests==2.28.0
+yapf==0.32.0


### PR DESCRIPTION
3.11 brings lots of optimizations that would slightly increase the speed from 3.6. This also bumps deps used in requirements

*(Please ensure you have read SUPPORT.md and docs/contributing.md before submitting the Pull Request)*
