### PR TITLE
Allow enabling hide-fullscreen-exit-ui on macOS

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
@@ -28,7 +28,7 @@
 @@ -120,4 +120,8 @@
       "Hide Fullscreen Exit UI",
       "Hides the \"X\" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode. Additionally, this hides the \"Press F11 to exit full screen\" popup. ungoogled-chromium flag.",
-      kOsLinux | kOsWin, SINGLE_VALUE_TYPE("hide-fullscreen-exit-ui")},
+      kOsDesktop, SINGLE_VALUE_TYPE("hide-fullscreen-exit-ui")},
 +    {"enable-incognito-themes",
 +     "Enable themes in Incognito mode",
 +     "Allows themes to override Google's built-in Incognito theming. ungoogled-chromium flag.",

--- a/patches/extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
@@ -33,5 +33,5 @@
 +    {"hide-fullscreen-exit-ui",
 +     "Hide Fullscreen Exit UI",
 +     "Hides the \"X\" that appears when the mouse cursor is moved towards the top of the window in fullscreen mode. Additionally, this hides the \"Press F11 to exit full screen\" popup. ungoogled-chromium flag.",
-+     kOsLinux | kOsWin, SINGLE_VALUE_TYPE("hide-fullscreen-exit-ui")},
++     kOsDesktop, SINGLE_VALUE_TYPE("hide-fullscreen-exit-ui")},
  #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_


### PR DESCRIPTION
The fullscreen exit popup appears on macOS as well now, making the first half of this patch applicable to that platform too:
![Fullscreen](https://user-images.githubusercontent.com/114500360/222467184-9267aff2-bb63-47e4-bec9-7ae43a917819.png)