### PR TITLE
Import three Debian patches to better modularize changes

### DIFF
--- a/patches/core/debian/disable/signin.patch
+++ b/patches/core/debian/disable/signin.patch
@@ -1,0 +1,37 @@
+description: disable browser sign-in
+origin: https://raw.githubusercontent.com/Eloston/ungoogled-chromium/master/resources/patches/ungoogled-chromium/disable-signin.patch
+
+--- a/chrome/browser/ui/webui/signin/inline_login_handler_impl.cc
++++ b/chrome/browser/ui/webui/signin/inline_login_handler_impl.cc
+@@ -401,17 +401,6 @@ void InlineSigninHelper::OnClientOAuthSu
+ 
+     signin_metrics::LogSigninReason(signin_metrics::Reason::kReauthentication);
+   } else {
+-    if (confirm_untrusted_signin_) {
+-      // Display a confirmation dialog to the user.
+-      base::RecordAction(
+-          base::UserMetricsAction("Signin_Show_UntrustedSigninPrompt"));
+-      Browser* browser = chrome::FindLastActiveWithProfile(profile_);
+-      browser->window()->ShowOneClickSigninConfirmation(
+-          base::UTF8ToUTF16(email_),
+-          base::BindOnce(&InlineSigninHelper::UntrustedSigninConfirmed,
+-                         base::Unretained(this), result.refresh_token));
+-      return;
+-    }
+     CreateSyncStarter(result.refresh_token);
+   }
+ 
+--- a/components/signin/internal/identity_manager/primary_account_manager.cc
++++ b/components/signin/internal/identity_manager/primary_account_manager.cc
+@@ -146,9 +146,9 @@ void PrimaryAccountManager::RegisterProf
+                                std::string());
+   registry->RegisterStringPref(prefs::kGoogleServicesAccountId, std::string());
+   registry->RegisterBooleanPref(prefs::kGoogleServicesConsentedToSync, false);
+-  registry->RegisterBooleanPref(prefs::kAutologinEnabled, true);
++  registry->RegisterBooleanPref(prefs::kAutologinEnabled, false);
+   registry->RegisterListPref(prefs::kReverseAutologinRejectedEmailList);
+-  registry->RegisterBooleanPref(prefs::kSigninAllowed, true);
++  registry->RegisterBooleanPref(prefs::kSigninAllowed, false);
+   registry->RegisterBooleanPref(prefs::kSignedInWithCredentialProvider, false);
+ }
+ 

--- a/patches/core/debian/disable/tests.patch
+++ b/patches/core/debian/disable/tests.patch
@@ -1,0 +1,10 @@
+--- a/third_party/devtools-frontend/src/BUILD.gn
++++ b/third_party/devtools-frontend/src/BUILD.gn
+@@ -13,7 +13,6 @@ import("./third_party/blink/public/publi
+ 
+ devtools_frontend_resources_deps = [
+   "front_end",
+-  "test",
+ ]
+ 
+ group("devtools_all_files") {

--- a/patches/core/debian/disable/third-party-cookies.patch
+++ b/patches/core/debian/disable/third-party-cookies.patch
@@ -1,0 +1,20 @@
+description: disable third-party cookies by default
+author: Andres Salomon <dilinger@debian.org>
+
+This is easily configured in
+  Settings -> Security & Privacy -> Cookies & other site data
+
+With this patch, we just change the default on a new chromium profile.
+
+
+--- a/components/content_settings/core/browser/cookie_settings.cc
++++ b/components/content_settings/core/browser/cookie_settings.cc
+@@ -68,7 +68,7 @@ void CookieSettings::RegisterProfilePref
+     user_prefs::PrefRegistrySyncable* registry) {
+   registry->RegisterIntegerPref(
+       prefs::kCookieControlsMode,
+-      static_cast<int>(CookieControlsMode::kIncognitoOnly),
++      static_cast<int>(CookieControlsMode::kBlockThirdParty),
+       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
+ }
+ 

--- a/patches/core/ungoogled-chromium/fix-building-with-prunned-binaries.patch
+++ b/patches/core/ungoogled-chromium/fix-building-with-prunned-binaries.patch
@@ -12,13 +12,3 @@
    # Linux
    executable("chromedriver_server.unstripped") {
      testonly = true
---- a/third_party/devtools-frontend/src/BUILD.gn
-+++ b/third_party/devtools-frontend/src/BUILD.gn
-@@ -13,7 +13,6 @@ import("./third_party/blink/public/publi
- 
- devtools_frontend_resources_deps = [
-   "front_end",
--  "test",
- ]
- 
- group("devtools_all_files") {

--- a/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
+++ b/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
@@ -5105,9 +5105,9 @@
 -                               std::string());
 -  registry->RegisterStringPref(prefs::kGoogleServicesAccountId, std::string());
 -  registry->RegisterBooleanPref(prefs::kGoogleServicesConsentedToSync, false);
--  registry->RegisterBooleanPref(prefs::kAutologinEnabled, true);
+-  registry->RegisterBooleanPref(prefs::kAutologinEnabled, false);
 -  registry->RegisterListPref(prefs::kReverseAutologinRejectedEmailList);
--  registry->RegisterBooleanPref(prefs::kSigninAllowed, true);
+-  registry->RegisterBooleanPref(prefs::kSigninAllowed, false);
 -  registry->RegisterBooleanPref(prefs::kSignedInWithCredentialProvider, false);
  }
  

--- a/patches/extra/inox-patchset/0006-modify-default-prefs.patch
+++ b/patches/extra/inox-patchset/0006-modify-default-prefs.patch
@@ -123,17 +123,6 @@
        user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
    registry->RegisterBooleanPref(prefs::kEditBookmarksEnabled, true);
    registry->RegisterBooleanPref(
---- a/components/content_settings/core/browser/cookie_settings.cc
-+++ b/components/content_settings/core/browser/cookie_settings.cc
-@@ -68,7 +68,7 @@ void CookieSettings::RegisterProfilePref
-     user_prefs::PrefRegistrySyncable* registry) {
-   registry->RegisterIntegerPref(
-       prefs::kCookieControlsMode,
--      static_cast<int>(CookieControlsMode::kIncognitoOnly),
-+      static_cast<int>(CookieControlsMode::kBlockThirdParty),
-       user_prefs::PrefRegistrySyncable::SYNCABLE_PREF);
- }
- 
 --- a/components/password_manager/core/browser/password_manager.cc
 +++ b/components/password_manager/core/browser/password_manager.cc
 @@ -255,14 +255,14 @@ base::CallbackListSubscription AddSyncEn

--- a/patches/series
+++ b/patches/series
@@ -4,7 +4,10 @@ core/inox-patchset/0005-disable-default-extensions.patch
 core/inox-patchset/0009-disable-google-ipv6-probes.patch
 core/inox-patchset/0015-disable-update-pings.patch
 core/inox-patchset/0021-disable-rlz.patch
+core/debian/disable/tests.patch
 core/debian/disable/unrar.patch
+core/debian/disable/signin.patch
+core/debian/disable/third-party-cookies.patch
 core/iridium-browser/safe_browsing-disable-incident-reporting.patch
 core/iridium-browser/safe_browsing-disable-reporting-of-safebrowsing-over.patch
 core/iridium-browser/all-add-trk-prefixes-to-possibly-evil-connections.patch


### PR DESCRIPTION
This PR aims to simplify building on Debian by importing three of their patches that currently conflict with later, larger u-c patches. This way, the u-c patches will apply cleanly after the Debian patch series, once the `patches/*/debian/` patches are left out.

Specifically, this change does the following:

1. Import these three patches from Debian (u-c paths shown):
   ```
   patches/core/debian/disable/signin.patch
   patches/core/debian/disable/tests.patch
   patches/core/debian/disable/third-party-cookies.patch
   ```
   (The upstream for these files can be browsed [here](https://sources.debian.org/src/chromium/111.0.5563.110-1/debian/patches/disable/), for reference)

2. Update the existing patches as follows:

   * Remove edit to `third_party/devtools-frontend/src/BUILD.gn`
     from `patches/core/ungoogled-chromium/fix-building-with-prunned-binaries.patch`
     as it is present in `patches/core/debian/disable/tests.patch`.

   * Modify edit to `components/signin/internal/identity_manager/primary_account_manager.cc`
     in `patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch`
     to account for changes made in `patches/core/debian/disable/signin.patch`.

     Note: `signin.patch` also contains a modification to `chrome/browser/ui/webui/signin/inline_login_handler_impl.cc` that is not currently part of the u-c patches. Please double-check it. I can update the PR to not include this modification, if desired.

   * Remove edit to `components/content_settings/core/browser/cookie_settings.cc`
     from `patches/extra/inox-patchset/0006-modify-default-prefs.patch`
     as it is present in `patches/core/debian/disable/third-party-cookies.patch`.

3. Add the new patches to `patches/series`, in the same order they are listed in the Debian patch series.


By the way, note that Debian has dropped two of their patches shipped by u-c, both in the chromium 105.0.5195.52-1 release. Here are the associated [changelog](https://metadata.ftp-master.debian.org/changelogs//main/c/chromium/unstable_changelog) comments:

> `disable/welcome-page.patch`: drop. Upstream fixed the original issue some time ago, and this new version finally cleaned up the workaround.

> `fixes/connection-message.patch`: drop it. I looked at sending this upstream, but the original extension doesn't exist any more, and chromium properly prints an error if a proxy is unreachable. If you can still reproduce the issue (described in http://bugs.debian.org/864539), let me know so I can get it fixed upstream.