### PR TITLE
Update patch to fix errors in Debian-based build

### DIFF
--- a/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
+++ b/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
@@ -2438,3 +2438,66 @@
      "//components/safe_browsing/content/browser/web_ui",
      "//components/safe_browsing/content/common:interfaces",
      "//components/safe_browsing/content/renderer:throttles",
+--- a/content/browser/file_system_access/fake_file_system_access_permission_context.cc
++++ b/content/browser/file_system_access/fake_file_system_access_permission_context.cc
+@@ -46,13 +46,6 @@ void FakeFileSystemAccessPermissionConte
+   std::move(callback).Run(SensitiveEntryResult::kAllowed);
+ }
+ 
+-void FakeFileSystemAccessPermissionContext::PerformAfterWriteChecks(
+-    std::unique_ptr<FileSystemAccessWriteItem> item,
+-    GlobalRenderFrameHostId frame_id,
+-    base::OnceCallback<void(AfterWriteCheckResult)> callback) {
+-  std::move(callback).Run(AfterWriteCheckResult::kAllow);
+-}
+-
+ bool FakeFileSystemAccessPermissionContext::CanObtainReadPermission(
+     const url::Origin& origin) {
+   return true;
+--- a/content/browser/file_system_access/fake_file_system_access_permission_context.h
++++ b/content/browser/file_system_access/fake_file_system_access_permission_context.h
+@@ -46,11 +46,6 @@ class FakeFileSystemAccessPermissionCont
+       GlobalRenderFrameHostId frame_id,
+       base::OnceCallback<void(SensitiveEntryResult)> callback) override;
+ 
+-  void PerformAfterWriteChecks(
+-      std::unique_ptr<FileSystemAccessWriteItem> item,
+-      GlobalRenderFrameHostId frame_id,
+-      base::OnceCallback<void(AfterWriteCheckResult)> callback) override;
+-
+   bool CanObtainReadPermission(const url::Origin& origin) override;
+   bool CanObtainWritePermission(const url::Origin& origin) override;
+ 
+--- a/content/browser/file_system_access/mock_file_system_access_permission_context.cc
++++ b/content/browser/file_system_access/mock_file_system_access_permission_context.cc
+@@ -23,11 +23,4 @@ void MockFileSystemAccessPermissionConte
+                                user_action, frame_id, callback);
+ }
+ 
+-void MockFileSystemAccessPermissionContext::PerformAfterWriteChecks(
+-    std::unique_ptr<FileSystemAccessWriteItem> item,
+-    GlobalRenderFrameHostId frame_id,
+-    base::OnceCallback<void(AfterWriteCheckResult)> callback) {
+-  PerformAfterWriteChecks_(item.get(), frame_id, callback);
+-}
+-
+ }  // namespace content
+--- a/content/browser/file_system_access/mock_file_system_access_permission_context.h
++++ b/content/browser/file_system_access/mock_file_system_access_permission_context.h
+@@ -54,16 +54,6 @@ class MockFileSystemAccessPermissionCont
+                GlobalRenderFrameHostId frame_id,
+                base::OnceCallback<void(SensitiveEntryResult)>& callback));
+ 
+-  void PerformAfterWriteChecks(
+-      std::unique_ptr<FileSystemAccessWriteItem> item,
+-      GlobalRenderFrameHostId frame_id,
+-      base::OnceCallback<void(AfterWriteCheckResult)> callback) override;
+-  MOCK_METHOD(void,
+-              PerformAfterWriteChecks_,
+-              (FileSystemAccessWriteItem * item,
+-               GlobalRenderFrameHostId frame_id,
+-               base::OnceCallback<void(AfterWriteCheckResult)>& callback));
+-
+   MOCK_METHOD(bool,
+               CanObtainReadPermission,
+               (const url::Origin& origin),


### PR DESCRIPTION
In building a Debian Chromium-based ungoogled-chromium on the 111.0.5563.110 source, I encountered only a couple of minor compilation errors. My presumption is that these are coming up due to the additional build flags set by Debian.

(This build included the u-c GN flags. An earlier attempt was giving me numerous errors in the SafeBrowsing code, before I realized that this was necessary.)


```
In file included from ../../content/browser/file_system_access/fake_file_system_access_permission_context.cc:5:
../../content/browser/file_system_access/fake_file_system_access_permission_context.h:52:65: error: only virtual member functions can be marked 'override'
      base::OnceCallback<void(AfterWriteCheckResult)> callback) override;
                                                                ^~~~~~~~
1 error generated.
```
The `core/ungoogled-chromium/fix-building-without-safebrowsing.patch` patch removes the `PerformAfterWriteChecks()` method from the `FileSystemAccessPermissionContext` class in `content/public/browser/file_system_access_permission_context.h`, but does not remove it from the `FakeFileSystemAccessPermissionContext` subclass in `content/browser/file_system_access/fake_file_system_access_permission_context.{h,cc}`.

```
In file included from ../../content/browser/file_system_access/mock_file_system_access_permission_context.cc:5:
../../content/browser/file_system_access/mock_file_system_access_permission_context.h:60:65: error: only virtual member functions can be marked 'override'
      base::OnceCallback<void(AfterWriteCheckResult)> callback) override;
                                                                ^~~~~~~~
1 error generated.
```

The same occurs here. The `MockFileSystemAccessPermissionContext` subclass in `content/browser/file_system_access/mock_file_system_access_permission_context.{h,cc}` needs the same method removed.

This PR updates the patch in question, and yields a clean build for me.

