### PR TITLE
New version check: error on null/empty

### DIFF
--- a/.github/workflows/new_version_check.yml
+++ b/.github/workflows/new_version_check.yml
@@ -23,9 +23,10 @@ jobs:
       - name: Get the latest Chromium version
         id: latest-version
         run: |
-          echo "linux_version=$( curl -s 'https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases?filter=endtime=none&order_by=version%20desc'  | jq -rc '.releases | first | .version' )" >> $GITHUB_OUTPUT
-          echo "win_version=$( curl -s 'https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/stable/versions/all/releases?filter=endtime=none&order_by=version%20desc'  | jq -rc '.releases | first | .version' )" >> $GITHUB_OUTPUT
-          echo "mac_version=$( curl -s 'https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=endtime=none&order_by=version%20desc'  | jq -rc '.releases | first | .version' )" >> $GITHUB_OUTPUT
+          set -e
+          echo "linux_version=$( curl -s 'https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases?filter=endtime=none&order_by=version%20desc'  | jq -re '.releases | first | .version' )" >> $GITHUB_OUTPUT
+          echo "win_version=$( curl -s 'https://versionhistory.googleapis.com/v1/chrome/platforms/win/channels/stable/versions/all/releases?filter=endtime=none&order_by=version%20desc'  | jq -re '.releases | first | .version' )" >> $GITHUB_OUTPUT
+          echo "mac_version=$( curl -s 'https://versionhistory.googleapis.com/v1/chrome/platforms/mac/channels/stable/versions/all/releases?filter=endtime=none&order_by=version%20desc'  | jq -re '.releases | first | .version' )" >> $GITHUB_OUTPUT
       - uses: actions/checkout@v3
       - name: Create Issue for all platforms
         if: |


### PR DESCRIPTION
This PR fixes a bug with the new version check action mentioned in #2347 using the fix suggested by @rany2.
