### PR TITLE
Set default WebRTC policy, add default settings documentation

### DIFF
--- a/docs/default_settings.md
+++ b/docs/default_settings.md
@@ -1,0 +1,21 @@
+# Default Settings
+
+Vanilla Chromium settings are not often changed by ungoogled-chromium, however there are some exceptions.  
+Below is a list of the documented changes to the default Chromium settings.
+
+Setting | New State | Location
+-- | -- | --
+Allow sites to check if you have payment methods saved | Disabled | chrome://settings/payments
+Ask where to save each file before downloading | Enabled | chrome://settings/downloads
+Auto sign-in | Disabled | chrome://settings/passwords
+Block third-party cookies | Enabled | chrome://settings/cookies
+Clear cookies and site data when you close all windows | Enabled | chrome://settings/cookies
+Continue running background apps when Chromium is closed | Disabled | chrome://settings/system
+Hyperlink auditing (\<a ping>) | Disabled | NA
+Link Doctor | Disabled | NA
+Offer to save passwords | Disabled | chrome://settings/passwords
+Payment autofill | Disabled | chrome://settings/payments
+Preload pages | Disabled | chrome://settings/cookies
+Search suggestions | Disabled | chrome://settings/syncSetup
+Show bookmark bar | Enabled | chrome://settings/appearance
+WebRTC IP handling policy | Disable Non-Proxied UDP | `--webrtc-ip-handling-policy`

--- a/patches/extra/ungoogled-chromium/default-webrtc-ip-handling-policy.patch
+++ b/patches/extra/ungoogled-chromium/default-webrtc-ip-handling-policy.patch
@@ -1,0 +1,11 @@
+--- a/chrome/browser/ui/browser_ui_prefs.cc
++++ b/chrome/browser/ui/browser_ui_prefs.cc
+@@ -91,7 +91,7 @@ void RegisterBrowserUserPrefs(user_prefs
+                                 false);
+ #endif
+   registry->RegisterStringPref(prefs::kWebRTCIPHandlingPolicy,
+-                               blink::kWebRTCIPHandlingDefault);
++                               blink::kWebRTCIPHandlingDisableNonProxiedUdp);
+   registry->RegisterStringPref(prefs::kWebRTCUDPPortRange, std::string());
+   registry->RegisterBooleanPref(prefs::kWebRtcEventLogCollectionAllowed, false);
+   registry->RegisterListPref(prefs::kWebRtcLocalIpsAllowedUrls);

--- a/patches/series
+++ b/patches/series
@@ -99,3 +99,4 @@ extra/ungoogled-chromium/add-flag-to-hide-extensions-menu.patch
 extra/ungoogled-chromium/add-flag-to-hide-fullscreen-exit-ui.patch
 extra/ungoogled-chromium/add-flag-for-incognito-themes.patch
 extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
+extra/ungoogled-chromium/default-webrtc-ip-handling-policy.patch


### PR DESCRIPTION
This PR sets the WebRTC IP handling policy to disable non-proxied UDP by default.  This also introduces new documentation for the default settings changed by ungoogled-chromium.  

The WebRTC IP handling policy can be changed with the existing `--webrtc-ip-handling-policy` switch and #1687 adds an entry in chrome://flags.  

This default may no longer be necessary if mDNS is re-enabled in #2116.