### PR TITLE
Fix linking chromedriver

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
+++ b/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
@@ -150,6 +150,18 @@
 +}  // namespace referrer_sanitizer
 +
 +#endif  // CHROME_COMMON_REFERRER_SANITIZER_H_
+--- a/chrome/test/chromedriver/BUILD.gn
++++ b/chrome/test/chromedriver/BUILD.gn
+@@ -312,8 +312,7 @@ source_set("lib") {
+     "//base/third_party/dynamic_annotations",
+     "//build:branding_buildflags",
+     "//build:chromeos_buildflags",
+-    "//chrome/common:constants",
+-    "//chrome/common:version_header",
++    "//chrome/common",
+     "//chrome/test/chromedriver/constants:version_header",
+     "//components/crx_file",
+     "//components/embedder_support",
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
 @@ -41,6 +41,7 @@
@@ -300,3 +312,13 @@
  }
  
  mojom::ControllerServiceWorkerMode
+--- a/tools/v8_context_snapshot/BUILD.gn
++++ b/tools/v8_context_snapshot/BUILD.gn
+@@ -82,6 +82,7 @@ if (use_v8_context_snapshot) {
+       sources = [ "v8_context_snapshot_generator.cc" ]
+ 
+       deps = [
++        "//chrome/common",
+         "//gin:gin",
+         "//mojo/core/embedder",
+         "//services/service_manager/public/cpp",


### PR DESCRIPTION
Turns out that the fix to the referrer patch in the windows repo isn't actually windows-specific, but is actually needed on all platforms to fix linking ```chromedriver```. All credit goes to @teeminus for this patch.