### PR TITLE
Fix linking content_shell

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
+++ b/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
@@ -162,6 +162,35 @@
      "//chrome/test/chromedriver/constants:version_header",
      "//components/crx_file",
      "//components/embedder_support",
+--- a/components/BUILD.gn
++++ b/components/BUILD.gn
+@@ -51,7 +51,7 @@ if (is_ios) {
+ 
+ # Omit Lacros because it allows //components to depend on //chrome, which in
+ # turn depends on //extensions.
+-if (!is_chromeos_lacros) {
++if (false) {
+   disallowed_extension_deps_ = [
+     # Components should largely not depend on //extensions. Since // extensions
+     # is not a component target and is linked with //chrome, depending on most
+@@ -709,7 +709,7 @@ test("components_unittests") {
+   # On other platforms, no components should depend on Chrome.
+   # Since //chrome depends on //extensions, we also only assert_no_deps on
+   # extensions targets for non-lacros builds.
+-  if (!is_chromeos_lacros) {
++  if (false) {
+     assert_no_deps = [ "//chrome/*" ]
+     assert_no_deps += disallowed_extension_deps_
+   }
+@@ -988,7 +988,7 @@ if (use_blink) {
+     # dependency. On other platforms, no components should depend on Chrome.
+     # Since //chrome depends on //extensions, we also only assert_no_deps on
+     # extensions targets for non-lacros builds.
+-    if (!is_chromeos_lacros) {
++    if (false) {
+       assert_no_deps = [ "//chrome/*" ]
+       assert_no_deps += disallowed_extension_deps_
+     }
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
 @@ -41,6 +41,7 @@
@@ -215,6 +244,16 @@
  }
  
  void RenderFrameImpl::DidLoadResourceFromMemoryCache(
+--- a/content/shell/BUILD.gn
++++ b/content/shell/BUILD.gn
+@@ -266,6 +266,7 @@ static_library("content_shell_lib") {
+     "//base/third_party/dynamic_annotations",
+     "//build:chromeos_buildflags",
+     "//cc/base",
++    "//chrome/common",
+     "//components/cdm/renderer",
+     "//components/custom_handlers",
+     "//components/custom_handlers:test_support",
 --- a/services/network/network_service_network_delegate.cc
 +++ b/services/network/network_service_network_delegate.cc
 @@ -12,6 +12,7 @@


### PR DESCRIPTION
Fixes #2393 according to feedback. This is slightly hacky as we have to override a few assertions to convince the build system to link ```content_shell_lib``` with ```chrome/common```.