### PR TITLE
Remove non-functional Live Caption checkbox from media controls

### DIFF
--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -20,6 +20,7 @@
 # the (?) learn more button on many settings pages
 # unneeded elements from the profile menu
 # the 'Learn more' link on crashed tabs
+# disable LiveCaption flag by default, this also removes non-functional Live Caption checkbox from media controls
 
 --- a/chrome/browser/resources/extensions/item_list.html
 +++ b/chrome/browser/resources/extensions/item_list.html
@@ -331,3 +332,14 @@
    action_button_ =
        actions_container->AddChildView(std::make_unique<views::MdTextButton>(
            base::BindRepeating(&SadTabView::PerformAction,
+--- a/media/base/media_switches.cc
++++ b/media/base/media_switches.cc
+@@ -830,7 +830,7 @@
+ #endif  // BUILDFLAG(IS_WIN)
+ 
+ // Enables the Live Caption feature on supported devices.
+-BASE_FEATURE(kLiveCaption, "LiveCaption", base::FEATURE_ENABLED_BY_DEFAULT);
++BASE_FEATURE(kLiveCaption, "LiveCaption", base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ // Controls whether a "Share this tab instead" button should be shown for
+ // getDisplayMedia captures. Note: This flag does not control if the "Share this


### PR DESCRIPTION
Before:
![livecapt](https://github.com/ungoogled-software/ungoogled-chromium/assets/10319700/c27e6d47-85f0-4c54-b194-f21d686396f1)
After:
![image](https://github.com/ungoogled-software/ungoogled-chromium/assets/10319700/88b0aec9-29a3-4ce9-a1f3-50c59a327b29)

<s>Maybe we could also add `enable_speech_service=false` to gn flags.</s> Disabling speech services also removes media controls.