### PR TITLE
Remove additional references to pruned materials (to fix Debian build)

### DIFF
--- a/patches/core/ungoogled-chromium/fix-building-with-prunned-binaries.patch
+++ b/patches/core/ungoogled-chromium/fix-building-with-prunned-binaries.patch
@@ -23,6 +23,26 @@
    # Linux
    executable("chromedriver_server.unstripped") {
      testonly = true
+--- a/chrome/test/variations/BUILD.gn
++++ b/chrome/test/variations/BUILD.gn
+@@ -49,6 +49,5 @@
+     ":test_utils",
+     "//testing:run_isolated_script_test",
+     "//testing:test_scripts_shared",
+-    "//third_party/catapult/third_party/gsutil:gsutil",
+   ]
+ }
+--- a/components/update_client/BUILD.gn
++++ b/components/update_client/BUILD.gn
+@@ -308,8 +308,6 @@
+     "//third_party/puffin:libpuffpatch",
+     "//third_party/re2",
+   ]
+-
+-  data_deps = [ "//components/test/data/update_client/puffin_patch_test:puffin_patch_test_files" ]
+ }
+ 
+ fuzzer_test("update_client_protocol_serializer_fuzzer") {
 --- a/content/shell/BUILD.gn
 +++ b/content/shell/BUILD.gn
 @@ -728,10 +728,6 @@ if (is_apple) {
@@ -46,3 +66,13 @@
  ]
  
  group("devtools_all_files") {
+--- a/third_party/puffin/BUILD.gn
++++ b/third_party/puffin/BUILD.gn
+@@ -115,7 +115,6 @@
+     "src/unittest_common.cc",
+     "src/utils_unittest.cc",
+   ]
+-  data_deps = [ "//components/test/data/update_client/puffin_patch_test:puffin_patch_test_files" ]
+   deps = [
+     ":libpuffdiff",
+     ":libpuffpatch",


### PR DESCRIPTION
In building ungoogled-chromium based on the Debian 116.0.5845.96-2 source, I encountered the following error:
```
gn gen out/Release --args="clang_use_chrome_plugins=false rust_sysroot_absolute=\"/usr\" rustc_version=\"rustc 1.66.1 (90743e729 2023-01-10) (built from a source tarball)\" enable_rust=false clang_base_path=\"/usr/lib/llvm-\" clang_version=\"""\" host_toolchain=\"//build/toolchain/linux/unbundle:default\" custom_toolchain=\"//build/toolchain/linux/unbundle:default\" host_cpu=\"x64\" use_vaapi=true is_debug=false use_goma=false use_sysroot=false use_libjpeg_turbo=true use_custom_libcxx=false use_unofficial_version_number=false enable_vr=false enable_nacl=false enable_swiftshader=false dawn_use_swiftshader=false build_dawn_tests=false enable_reading_list=false enable_iterator_debugging=false enable_hangout_services_extension=false angle_has_histograms=false build_angle_perftests=false treat_warnings_as_errors=false use_qt=false is_cfi=false use_thin_lto=true chrome_pgo_phase=0  use_gio=true is_official_build=true symbol_level=0 use_pulseaudio=true link_pulseaudio=true rtc_use_pipewire=true icu_use_data_file=true enable_widevine=true v8_enable_backtrace=true use_system_zlib=true use_system_lcms2=true use_system_libjpeg=true use_system_libpng=true use_system_freetype=true use_system_libopenjpeg2=true  proprietary_codecs=true ffmpeg_branding=\"Chrome\" disable_fieldtrial_testing_config=true  build_with_tflite_lib=false chrome_pgo_phase=0 clang_use_chrome_plugins=false disable_fieldtrial_testing_config=true enable_hangout_services_extension=false enable_mdns=false enable_mse_mpeg2ts_stream_parser=true enable_nacl=false enable_reading_list=false enable_remoting=false enable_reporting=false enable_service_discovery=false enable_widevine=true exclude_unwind_tables=true google_api_key=\"\" google_default_client_id=\"\" google_default_client_secret=\"\" safe_browsing_mode=0 treat_warnings_as_errors=false use_official_google_api_keys=false use_unofficial_version_number=false "
ERROR at //components/update_client/BUILD.gn:312:17: Unable to load "/home/build/ungoogled-chromium/ungoogled-chromium-116.0.5845.96/components/test/data/update_client/puffin_patch_test/BUILD.gn".
  data_deps = [ "//components/test/data/update_client/puffin_patch_test:puffin_patch_test_files" ]
                ^-------------------------------------------------------------------------------
make[1]: *** [debian/rules:142: override_dh_auto_build-arch] Error 1
```

The `puffin_patch_test` directory is absent from the Debian source. References to it are removed in Debian's [`disable/tests.patch`](https://salsa.debian.org/chromium-team/chromium/-/blob/master/debian/patches/disable/tests.patch) file. That patch, however, conflict's with u-c's `fix-building-with-prunned-binaries.patch`, as they both make the same edit to `third_party/devtools-frontend/src/BUILD.gn`.

This PR fixes the above error (and allows a successful build) by adding in the recent updates to Debian's patch, removing references not only to `puffin_patch_test`, but also to `third_party/catapult/third_party/gsutil`. Both locations have files in u-c's pruning list.

As an alternate approach, you might consider importing the Debian patch in whole, and removing the common edit from u-c's. (Before, Debian's had *only* that one edit, so it arguably wasn't worth bothering with at the time.) If this is preferable, I can update the PR accordingly.