### PR TITLE
Cirrus CI updates

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,3 +1,6 @@
+env:
+    CIRRUS_CLONE_DEPTH: 1
+
 container:
     dockerfile: .cirrus_Dockerfile
     cpu: 5

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,8 @@
 container:
     dockerfile: .cirrus_Dockerfile
+    cpu: 5
+    memory: 20G
+    use_in_memory_disk: true
 
 code_check_task:
     pip_cache:


### PR DESCRIPTION
Cirrus CI has a new 8G limit for storage which isn't large enough for one our tasks.  
They allow up to 32G of memory though, so lets see if we can run in-memory instead!  