### PR TITLE
Verbose patch validation

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -52,7 +52,7 @@ validate_with_source_task:
           ./utils/downloads.py unpack --skip-unused -i downloads.ini -c chromium_download_cache chromium_src
         fi
     validate_patches_script:
-        - ./devutils/validate_patches.py -l chromium_src
+        - ./devutils/validate_patches.py -l chromium_src -v
     validate_lists_script:
         # NOTE: This check is prone to false positives, but not false negatives.
         - ./devutils/check_files_exist.py chromium_src pruning.list domain_substitution.list


### PR DESCRIPTION
This should make patch validation verbose, which allows someone not familiar with our workflows to infer what the issue with patches might be.