### PR TITLE
Use raw strings for placeholders in depot_tools patch

### DIFF
--- a/utils/depot_tools.patch
+++ b/utils/depot_tools.patch
@@ -11,8 +11,8 @@
  
 -PREVIOUS_CUSTOM_VARS_FILE = '.gclient_previous_custom_vars'
 -PREVIOUS_SYNC_COMMITS_FILE = '.gclient_previous_sync_commits'
-+PREVIOUS_CUSTOM_VARS_FILE = 'UC_STAGING'+os.sep+'.gclient_previous_custom_vars'
-+PREVIOUS_SYNC_COMMITS_FILE = 'UC_STAGING'+os.sep+'.gclient_previous_sync_commits'
++PREVIOUS_CUSTOM_VARS_FILE = r'UC_STAGING'+os.sep+'.gclient_previous_custom_vars'
++PREVIOUS_SYNC_COMMITS_FILE = r'UC_STAGING'+os.sep+'.gclient_previous_sync_commits'
  
  PREVIOUS_SYNC_COMMITS = 'GCLIENT_PREVIOUS_SYNC_COMMITS'
  
@@ -20,7 +20,7 @@
                   protocol='https',
                   git_dependencies_state=gclient_eval.DEPS,
                   print_outbuf=False):
-+        if name and name[0:3] == "src": name = "UC_OUT"+name[3:]
++        if name and name[0:3] == "src": name = r"UC_OUT"+name[3:]
          gclient_utils.WorkItem.__init__(self, name)
          DependencySettings.__init__(self, parent, url, managed, custom_deps,
                                      custom_vars, custom_hooks, deps_file,
@@ -37,7 +37,7 @@
          self._gn_args_from = local_scope.get('gclient_gn_args_from')
          self._gn_args_file = local_scope.get('gclient_gn_args_file')
 +        if self._gn_args_file and self._gn_args_file[0:3] == "src":
-+            self._gn_args_file = "UC_OUT"+self._gn_args_file[3:]
++            self._gn_args_file = r"UC_OUT"+self._gn_args_file[3:]
          self._gn_args = local_scope.get('gclient_gn_args', [])
          # It doesn't make sense to set all of these, since setting gn_args_from
          # to another DEPS will make gclient ignore any other local gn_args*


### PR DESCRIPTION
The clone script currently does not work on windows as the windows path separator is the escape character for strings. Using raw strings fixes the issue with backslashes in the placeholder strings.