### PR TITLE
Update container and scripts for python 3.9

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ container:
 
 code_check_task:
     pip_cache:
-        folder: /usr/local/lib/python3.6/site-packages
+        folder: /usr/local/lib/python3.9/site-packages
         fingerprint_script: cat .cirrus_requirements.txt
         populate_script: pip install -r .cirrus_requirements.txt
     utils_script:
@@ -26,7 +26,7 @@ validate_config_task:
 
 validate_with_source_task:
     pip_cache:
-        folder: /usr/local/lib/python3.6/site-packages
+        folder: /usr/local/lib/python3.9/site-packages
         fingerprint_script: cat .cirrus_requirements.txt
         populate_script: pip install -r .cirrus_requirements.txt
     chromium_download_cache:

--- a/.cirrus_Dockerfile
+++ b/.cirrus_Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Python 3 with xz-utils (for tar.xz unpacking)
 
-FROM python:3.6-slim-buster
+FROM python:3.9-slim-bullseye
 
 RUN apt update && apt install -y xz-utils patch axel curl git

--- a/.cirrus_requirements.txt
+++ b/.cirrus_requirements.txt
@@ -1,8 +1,9 @@
-# Based on Python package versions in Debian buster
-astroid==2.1.0 # via pylint
-pylint==2.2.2
-pytest-cov==2.6.0
-pytest==3.10.1
-httplib2==0.11.3
-requests==2.21.0
-yapf==0.25.0
+# Based on Python package versions in Debian bullseye
+# https://packages.debian.org/bullseye/python/
+astroid==2.5.1 # via pylint
+pylint==2.7.2
+pytest-cov==2.10.1
+pytest==6.0.2
+httplib2==0.18.1
+requests==2.25.1
+yapf==0.30.0

--- a/devutils/check_downloads_ini.py
+++ b/devutils/check_downloads_ini.py
@@ -55,8 +55,8 @@ def main():
     args = parser.parse_args()
 
     if check_downloads_ini(args.downloads_ini):
-        exit(1)
-    exit(0)
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/devutils/check_downloads_ini.py
+++ b/devutils/check_downloads_ini.py
@@ -46,13 +46,12 @@ def main():
     default_downloads_ini = [str(root_dir / 'downloads.ini')]
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        '-d',
-        '--downloads-ini',
-        type=Path,
-        nargs='*',
-        default=default_downloads_ini,
-        help='List of downloads.ini files to check. Default: %(default)s')
+    parser.add_argument('-d',
+                        '--downloads-ini',
+                        type=Path,
+                        nargs='*',
+                        default=default_downloads_ini,
+                        help='List of downloads.ini files to check. Default: %(default)s')
     args = parser.parse_args()
 
     if check_downloads_ini(args.downloads_ini):

--- a/devutils/check_files_exist.py
+++ b/devutils/check_files_exist.py
@@ -30,7 +30,7 @@ def main():
                 print('ERROR: Path "{}" from file "{}" does not exist.'.format(
                     file_name, input_name),
                       file=sys.stderr)
-                exit(1)
+                sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/devutils/check_files_exist.py
+++ b/devutils/check_files_exist.py
@@ -27,9 +27,9 @@ def main():
                      Path(input_name).read_text(encoding='UTF-8').splitlines()))
         for file_name in file_iter:
             if not Path(args.root_dir, file_name).exists():
-                print(
-                    'ERROR: Path "{}" from file "{}" does not exist.'.format(file_name, input_name),
-                    file=sys.stderr)
+                print('ERROR: Path "{}" from file "{}" does not exist.'.format(
+                    file_name, input_name),
+                      file=sys.stderr)
                 exit(1)
 
 

--- a/devutils/check_gn_flags.py
+++ b/devutils/check_gn_flags.py
@@ -71,8 +71,8 @@ def main():
     args = parser.parse_args()
 
     if check_gn_flags(args.flags_gn):
-        exit(1)
-    exit(0)
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/devutils/check_gn_flags.py
+++ b/devutils/check_gn_flags.py
@@ -63,12 +63,11 @@ def main():
     default_flags_gn = root_dir / 'flags.gn'
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        '-f',
-        '--flags-gn',
-        type=Path,
-        default=default_flags_gn,
-        help='Path to the GN flags to use. Default: %(default)s')
+    parser.add_argument('-f',
+                        '--flags-gn',
+                        type=Path,
+                        default=default_flags_gn,
+                        help='Path to the GN flags to use. Default: %(default)s')
     args = parser.parse_args()
 
     if check_gn_flags(args.flags_gn):

--- a/devutils/check_patch_files.py
+++ b/devutils/check_patch_files.py
@@ -118,12 +118,11 @@ def main():
     default_patches_dir = root_dir / 'patches'
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        '-p',
-        '--patches',
-        type=Path,
-        default=default_patches_dir,
-        help='Path to the patches directory to use. Default: %(default)s')
+    parser.add_argument('-p',
+                        '--patches',
+                        type=Path,
+                        default=default_patches_dir,
+                        help='Path to the patches directory to use. Default: %(default)s')
     args = parser.parse_args()
 
     warnings = False

--- a/devutils/check_patch_files.py
+++ b/devutils/check_patch_files.py
@@ -23,7 +23,7 @@ from pathlib import Path
 from third_party import unidiff
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'utils'))
-from _common import ENCODING, get_logger, parse_series
+from _common import ENCODING, get_logger, parse_series # pylint: disable=wrong-import-order
 sys.path.pop(0)
 
 # File suffixes to ignore for checking unused patches
@@ -131,8 +131,8 @@ def main():
     warnings |= check_unused_patches(args.patches)
 
     if warnings:
-        exit(1)
-    exit(0)
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/devutils/run_devutils_pylint.py
+++ b/devutils/run_devutils_pylint.py
@@ -24,6 +24,7 @@ def main():
     disables = [
         'wrong-import-position',
         'bad-continuation',
+        'duplicate-code',
     ]
 
     if args.hide_fixme:
@@ -53,8 +54,8 @@ def main():
     sys.path.pop(2)
     sys.path.pop(1)
     if not result:
-        exit(1)
-    exit(0)
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/devutils/run_devutils_pylint.py
+++ b/devutils/run_devutils_pylint.py
@@ -16,10 +16,9 @@ def main():
     """CLI entrypoint"""
     parser = argparse.ArgumentParser(description='Run Pylint over devutils')
     parser.add_argument('--hide-fixme', action='store_true', help='Hide "fixme" Pylint warnings.')
-    parser.add_argument(
-        '--show-locally-disabled',
-        action='store_true',
-        help='Show "locally-disabled" Pylint warnings.')
+    parser.add_argument('--show-locally-disabled',
+                        action='store_true',
+                        help='Show "locally-disabled" Pylint warnings.')
     args = parser.parse_args()
 
     disables = [

--- a/devutils/run_other_pylint.py
+++ b/devutils/run_other_pylint.py
@@ -8,6 +8,7 @@
 import argparse
 import os
 import shutil
+import sys
 from pathlib import Path
 
 from pylint import lint
@@ -38,7 +39,7 @@ def run_pylint(module_path, pylint_options, ignore_prefixes=tuple()):
     input_paths = list()
     if not module_path.exists():
         print('ERROR: Cannot find', module_path)
-        exit(1)
+        sys.exit(1)
     if module_path.is_dir():
         for path in module_path.rglob('*.py'):
             ignore_matched = False
@@ -75,7 +76,7 @@ def main():
 
     if not args.module_path.exists():
         print('ERROR: Module path "{}" does not exist'.format(args.module_path))
-        exit(1)
+        sys.exit(1)
 
     disables = [
         'wrong-import-position',
@@ -95,8 +96,8 @@ def main():
     ]
 
     if not run_pylint(args.module_path, pylint_options):
-        exit(1)
-    exit(0)
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/devutils/run_other_pylint.py
+++ b/devutils/run_other_pylint.py
@@ -17,7 +17,6 @@ class ChangeDir:
     """
     Changes directory to path in with statement
     """
-
     def __init__(self, path):
         self._path = path
         self._orig_path = os.getcwd()
@@ -68,10 +67,9 @@ def main():
 
     parser = argparse.ArgumentParser(description='Run Pylint over arbitrary module')
     parser.add_argument('--hide-fixme', action='store_true', help='Hide "fixme" Pylint warnings.')
-    parser.add_argument(
-        '--show-locally-disabled',
-        action='store_true',
-        help='Show "locally-disabled" Pylint warnings.')
+    parser.add_argument('--show-locally-disabled',
+                        action='store_true',
+                        help='Show "locally-disabled" Pylint warnings.')
     parser.add_argument('module_path', type=Path, help='Path to the module to check')
     args = parser.parse_args()
 

--- a/devutils/run_utils_pylint.py
+++ b/devutils/run_utils_pylint.py
@@ -41,6 +41,7 @@ def main():
     ]
 
     sys.path.insert(1, str(Path(__file__).resolve().parent.parent / 'utils' / 'third_party'))
+    sys.path.append(Path(__file__).resolve().parent.parent / 'utils')
     with ChangeDir(Path(__file__).resolve().parent.parent / 'utils'):
         result = run_pylint(
             Path(),
@@ -49,8 +50,8 @@ def main():
         )
     sys.path.pop(1)
     if not result:
-        exit(1)
-    exit(0)
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/devutils/run_utils_pylint.py
+++ b/devutils/run_utils_pylint.py
@@ -16,10 +16,9 @@ def main():
     """CLI entrypoint"""
     parser = argparse.ArgumentParser(description='Run Pylint over utils')
     parser.add_argument('--hide-fixme', action='store_true', help='Hide "fixme" Pylint warnings.')
-    parser.add_argument(
-        '--show-locally-disabled',
-        action='store_true',
-        help='Show "locally-disabled" Pylint warnings.')
+    parser.add_argument('--show-locally-disabled',
+                        action='store_true',
+                        help='Show "locally-disabled" Pylint warnings.')
     args = parser.parse_args()
 
     disable = ['bad-continuation']

--- a/devutils/tests/test_check_patch_files.py
+++ b/devutils/tests/test_check_patch_files.py
@@ -5,19 +5,30 @@
 # found in the LICENSE file.
 """Test check_patch_files.py"""
 
+import logging
 import tempfile
+import sys
 from pathlib import Path
 
-from ..check_patch_files import check_series_duplicates
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / 'utils'))
+from _common import get_logger, set_logging_level
+sys.path.pop(0)
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from check_patch_files import check_series_duplicates
+sys.path.pop(0)
 
 
 def test_check_series_duplicates():
     """Test check_series_duplicates"""
+
+    set_logging_level(logging.DEBUG)
+
     with tempfile.TemporaryDirectory() as tmpdirname:
         patches_dir = Path(tmpdirname)
         series_path = Path(tmpdirname, 'series')
 
-        # Check no duplicates
+        get_logger().info('Check no duplicates')
         series_path.write_text('\n'.join([
             'a.patch',
             'b.patch',
@@ -25,7 +36,7 @@ def test_check_series_duplicates():
         ]))
         assert not check_series_duplicates(patches_dir)
 
-        # Check duplicates
+        get_logger().info('Check duplicates')
         series_path.write_text('\n'.join([
             'a.patch',
             'b.patch',
@@ -33,3 +44,7 @@ def test_check_series_duplicates():
             'a.patch',
         ]))
         assert check_series_duplicates(patches_dir)
+
+
+if __name__ == '__main__':
+    test_check_series_duplicates()

--- a/devutils/tests/test_validate_patches.py
+++ b/devutils/tests/test_validate_patches.py
@@ -11,18 +11,19 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / 'utils'))
-from _common import LOGGER_NAME
+from _common import get_logger, set_logging_level
 sys.path.pop(0)
 
-from .. import validate_patches
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import validate_patches
+sys.path.pop(0)
 
 
-def test_test_patches(caplog):
+def test_test_patches():
     """Test _dry_check_patched_file"""
 
     #pylint: disable=protected-access
-    caplog.set_level(logging.DEBUG, logger=LOGGER_NAME)
-    #set_logging_level(logging.DEBUG)
+    set_logging_level(logging.DEBUG)
 
     orig_file_content = """bye world"""
     series_iter = ['test.patch']
@@ -37,7 +38,7 @@ def test_test_patches(caplog):
                                                                       Path(tmpdirname))
             return validate_patches._test_patches(series_iter, patch_cache, files_under_test)
 
-    # Check valid modification
+    get_logger().info('Check valid modification')
     patch_content = """--- a/foobar.txt
 +++ b/foobar.txt
 @@ -1 +1 @@
@@ -46,7 +47,7 @@ def test_test_patches(caplog):
 """
     assert not _run_test_patches(patch_content)
 
-    # Check invalid modification
+    get_logger().info('Check invalid modification')
     patch_content = """--- a/foobar.txt
 +++ b/foobar.txt
 @@ -1 +1 @@
@@ -55,7 +56,7 @@ def test_test_patches(caplog):
 """
     assert _run_test_patches(patch_content)
 
-    # Check correct removal
+    get_logger().info('Check correct removal')
     patch_content = """--- a/foobar.txt
 +++ /dev/null
 @@ -1 +0,0 @@
@@ -63,10 +64,14 @@ def test_test_patches(caplog):
 """
     assert not _run_test_patches(patch_content)
 
-    # Check incorrect removal
+    get_logger().info('Check incorrect removal')
     patch_content = """--- a/foobar.txt
 +++ /dev/null
 @@ -1 +0,0 @@
 -this line does not exist in foobar
 """
     assert _run_test_patches(patch_content)
+
+
+if __name__ == '__main__':
+    test_test_patches()

--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -276,7 +276,7 @@ def compute_lists_proc(path, source_tree, search_regex):
             domain_substitution_set, symlink_set)
 
 
-def compute_lists(source_tree, search_regex, processes):
+def compute_lists(source_tree, search_regex, processes): # pylint: disable=too-many-locals
     """
     Compute the binary pruning and domain substitution lists of the source tree.
     Returns a tuple of three items in the following order:
@@ -303,10 +303,12 @@ def compute_lists(source_tree, search_regex, processes):
     # Handle the returned data
     for (used_pep_set, used_pip_set, used_dep_set, used_dip_set, returned_pruning_set,
          returned_domain_sub_set, returned_symlink_set) in returned_data:
+        # pragma pylint: disable=no-member
         unused_patterns.pruning_exclude_patterns.difference_update(used_pep_set)
         unused_patterns.pruning_include_patterns.difference_update(used_pip_set)
         unused_patterns.domain_exclude_prefixes.difference_update(used_dep_set)
         unused_patterns.domain_include_patterns.difference_update(used_dip_set)
+        # pragma pylint: enable=no-member
         pruning_set.update(returned_pruning_set)
         domain_substitution_set.update(returned_domain_sub_set)
         symlink_set.update(returned_symlink_set)
@@ -366,7 +368,7 @@ def main(args_list=None):
         get_logger().info('Using existing source tree at %s', args.tree)
     else:
         get_logger().error('No source tree found. Aborting.')
-        exit(1)
+        sys.exit(1)
     get_logger().info('Computing lists...')
     pruning_set, domain_substitution_set, unused_patterns = compute_lists(
         args.tree,
@@ -378,7 +380,7 @@ def main(args_list=None):
     if unused_patterns.log_unused(args.error_unused) and args.error_unused:
         get_logger().error('Please update or remove unused patterns and/or prefixes. '
                            'The lists have still been updated with the remaining valid entries.')
-        exit(1)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -322,31 +322,27 @@ def compute_lists(source_tree, search_regex, processes):
 def main(args_list=None):
     """CLI entrypoint"""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        '--pruning',
-        metavar='PATH',
-        type=Path,
-        default='pruning.list',
-        help='The path to store pruning.list. Default: %(default)s')
-    parser.add_argument(
-        '--domain-substitution',
-        metavar='PATH',
-        type=Path,
-        default='domain_substitution.list',
-        help='The path to store domain_substitution.list. Default: %(default)s')
-    parser.add_argument(
-        '--domain-regex',
-        metavar='PATH',
-        type=Path,
-        default='domain_regex.list',
-        help='The path to domain_regex.list. Default: %(default)s')
-    parser.add_argument(
-        '-t',
-        '--tree',
-        metavar='PATH',
-        type=Path,
-        required=True,
-        help='The path to the source tree to use.')
+    parser.add_argument('--pruning',
+                        metavar='PATH',
+                        type=Path,
+                        default='pruning.list',
+                        help='The path to store pruning.list. Default: %(default)s')
+    parser.add_argument('--domain-substitution',
+                        metavar='PATH',
+                        type=Path,
+                        default='domain_substitution.list',
+                        help='The path to store domain_substitution.list. Default: %(default)s')
+    parser.add_argument('--domain-regex',
+                        metavar='PATH',
+                        type=Path,
+                        default='domain_regex.list',
+                        help='The path to domain_regex.list. Default: %(default)s')
+    parser.add_argument('-t',
+                        '--tree',
+                        metavar='PATH',
+                        type=Path,
+                        required=True,
+                        help='The path to the source tree to use.')
     parser.add_argument(
         '--processes',
         metavar='NUM',
@@ -354,17 +350,15 @@ def main(args_list=None):
         default=None,
         help=
         'The maximum number of worker processes to create. Defaults to the number of system CPUs.')
-    parser.add_argument(
-        '--domain-exclude-prefix',
-        metavar='PREFIX',
-        type=str,
-        action='append',
-        help='Additional exclusion for domain_substitution.list.')
-    parser.add_argument(
-        '--no-error-unused',
-        action='store_false',
-        dest='error_unused',
-        help='Do not treat unused patterns/prefixes as an error.')
+    parser.add_argument('--domain-exclude-prefix',
+                        metavar='PREFIX',
+                        type=str,
+                        action='append',
+                        help='Additional exclusion for domain_substitution.list.')
+    parser.add_argument('--no-error-unused',
+                        action='store_false',
+                        dest='error_unused',
+                        help='Do not treat unused patterns/prefixes as an error.')
     args = parser.parse_args(args_list)
     if args.domain_exclude_prefix is not None:
         DOMAIN_EXCLUDE_PREFIXES.extend(args.domain_exclude_prefix)

--- a/devutils/update_platform_patches.py
+++ b/devutils/update_platform_patches.py
@@ -127,8 +127,8 @@ def unmerge_platform_patches(platform_patches_dir):
         get_logger().error('Unable to find series.merged at: %s',
                            platform_patches_dir / _SERIES_MERGED)
         return False
-    new_series = filter(
-        len, (platform_patches_dir / _SERIES_MERGED).read_text(encoding=ENCODING).splitlines())
+    new_series = filter(len, (platform_patches_dir /
+                              _SERIES_MERGED).read_text(encoding=ENCODING).splitlines())
     new_series = filter((lambda x: x not in prepend_series), new_series)
     new_series = list(new_series)
     series_index = 0
@@ -157,14 +157,12 @@ def unmerge_platform_patches(platform_patches_dir):
 def main():
     """CLI Entrypoint"""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        'command',
-        choices=('merge', 'unmerge'),
-        help='Merge or unmerge ungoogled-chromium patches with platform patches')
-    parser.add_argument(
-        'platform_patches',
-        type=Path,
-        help='The path to the platform patches in GNU Quilt format to merge into')
+    parser.add_argument('command',
+                        choices=('merge', 'unmerge'),
+                        help='Merge or unmerge ungoogled-chromium patches with platform patches')
+    parser.add_argument('platform_patches',
+                        type=Path,
+                        help='The path to the platform patches in GNU Quilt format to merge into')
     args = parser.parse_args()
 
     repo_dir = Path(__file__).resolve().parent.parent

--- a/devutils/validate_config.py
+++ b/devutils/validate_config.py
@@ -50,8 +50,8 @@ def main():
     warnings |= check_downloads_ini([root_dir / 'downloads.ini'])
 
     if warnings:
-        exit(1)
-    exit(0)
+        sys.exit(1)
+    sys.exit(0)
 
 
 if __name__ == '__main__':

--- a/devutils/validate_patches.py
+++ b/devutils/validate_patches.py
@@ -38,7 +38,6 @@ try:
 
     class _VerboseRetry(urllib3.util.Retry):
         """A more verbose version of HTTP Adatper about retries"""
-
         def sleep_for_retry(self, response=None):
             """Sleeps for Retry-After, and logs the sleep time"""
             if response:
@@ -61,13 +60,12 @@ try:
     def _get_requests_session():
         session = requests.Session()
         http_adapter = requests.adapters.HTTPAdapter(
-            max_retries=_VerboseRetry(
-                total=10,
-                read=10,
-                connect=10,
-                backoff_factor=8,
-                status_forcelist=urllib3.Retry.RETRY_AFTER_STATUS_CODES,
-                raise_on_status=False))
+            max_retries=_VerboseRetry(total=10,
+                                      read=10,
+                                      connect=10,
+                                      backoff_factor=8,
+                                      status_forcelist=urllib3.Retry.RETRY_AFTER_STATUS_CODES,
+                                      raise_on_status=False))
         session.mount('http://', http_adapter)
         session.mount('https://', http_adapter)
         return session
@@ -126,7 +124,6 @@ def _validate_deps(deps_text):
 
 def _deps_var(deps_globals):
     """Return a function that implements DEPS's Var() function"""
-
     def _var_impl(var_name):
         """Implementation of Var() in DEPS"""
         return deps_globals['vars'][var_name]
@@ -445,8 +442,9 @@ def _retrieve_remote_files(file_iter):
                     last_progress = current_progress
                     logger.info('%d files downloaded', current_progress)
             try:
-                files[file_path] = _download_source_file(
-                    download_session, root_deps_tree, fallback_repo_manager, file_path).split('\n')
+                files[file_path] = _download_source_file(download_session, root_deps_tree,
+                                                         fallback_repo_manager,
+                                                         file_path).split('\n')
             except _NotInRepoError:
                 get_logger().warning('Could not find "%s" remotely. Skipping...', file_path)
     return files
@@ -580,10 +578,9 @@ def _test_patches(series_iter, patch_cache, files_under_test):
                 return True
             except: #pylint: disable=bare-except
                 get_logger().warning('Patch failed validation: %s', patch_path_str)
-                get_logger().debug(
-                    'Specifically, file "%s" caused exception while applying:',
-                    patched_file.path,
-                    exc_info=True)
+                get_logger().debug('Specifically, file "%s" caused exception while applying:',
+                                   patched_file.path,
+                                   exc_info=True)
                 return True
     return False
 
@@ -599,8 +596,9 @@ def _load_all_patches(series_iter, patches_dir):
     for relative_path in series_iter:
         if relative_path in unidiff_dict:
             continue
-        unidiff_dict[relative_path] = unidiff.PatchSet.from_filename(
-            str(patches_dir / relative_path), encoding=ENCODING)
+        unidiff_dict[relative_path] = unidiff.PatchSet.from_filename(str(patches_dir /
+                                                                         relative_path),
+                                                                     encoding=ENCODING)
         if not (patches_dir / relative_path).read_text(encoding=ENCODING).endswith('\n'):
             had_failure = True
             get_logger().warning('Patch file does not end with newline: %s',
@@ -644,20 +642,18 @@ def _get_files_under_test(args, required_files, parser):
 def main():
     """CLI Entrypoint"""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        '-s',
-        '--series',
-        type=Path,
-        metavar='FILE',
-        default=str(Path('patches', 'series')),
-        help='The series file listing patches to apply. Default: %(default)s')
-    parser.add_argument(
-        '-p',
-        '--patches',
-        type=Path,
-        metavar='DIRECTORY',
-        default='patches',
-        help='The patches directory to read from. Default: %(default)s')
+    parser.add_argument('-s',
+                        '--series',
+                        type=Path,
+                        metavar='FILE',
+                        default=str(Path('patches', 'series')),
+                        help='The series file listing patches to apply. Default: %(default)s')
+    parser.add_argument('-p',
+                        '--patches',
+                        type=Path,
+                        metavar='DIRECTORY',
+                        default='patches',
+                        help='The patches directory to read from. Default: %(default)s')
     add_common_params(parser)
 
     file_source_group = parser.add_mutually_exclusive_group(required=True)

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -33,7 +33,7 @@ To gain a deeper understanding of this updating process, have a read through [do
 * [`quilt`](http://savannah.nongnu.org/projects/quilt)
     * This is available in most (if not all) Linux distributions, and also Homebrew on macOS.
     * This utility facilitates most of the updating process, so it is important to learn how to use this. The manpage for quilt (as of early 2017) lacks an example of a workflow. There are multiple guides online, but [this guide from Debian](https://wiki.debian.org/UsingQuilt) and [the referenced guide on that page](https://raphaelhertzog.com/2012/08/08/how-to-use-quilt-to-manage-patches-in-debian-packages/) are the ones referenced in developing the current workflow.
-* Python 3.6 or newer
+* Python 3.9 or newer
     * `httplib2` and `six` are also required if you wish to utilize a source clone instead of the source tarball.
 
 ### Downloading the source code

--- a/utils/_common.py
+++ b/utils/_common.py
@@ -36,7 +36,6 @@ class ExtractorEnum: #pylint: disable=too-few-public-methods
 
 class SetLogLevel(argparse.Action): #pylint: disable=too-few-public-methods
     """Sets logging level based on command line arguments it receives"""
-
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         super(SetLogLevel, self).__init__(option_strings, dest, nargs=nargs, **kwargs)
 

--- a/utils/_common.py
+++ b/utils/_common.py
@@ -37,7 +37,7 @@ class ExtractorEnum: #pylint: disable=too-few-public-methods
 class SetLogLevel(argparse.Action): #pylint: disable=too-few-public-methods
     """Sets logging level based on command line arguments it receives"""
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
-        super(SetLogLevel, self).__init__(option_strings, dest, nargs=nargs, **kwargs)
+        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
     def __call__(self, parser, namespace, value, option_string=None):
         if option_string in ('--verbose', '-v'):

--- a/utils/_extraction.py
+++ b/utils/_extraction.py
@@ -161,7 +161,6 @@ def _extract_tar_with_python(archive_path, output_dir, relative_to, skip_unused)
 
     class NoAppendList(list):
         """Hack to workaround memory issues with large tar files"""
-
         def append(self, obj):
             pass
 

--- a/utils/_extraction.py
+++ b/utils/_extraction.py
@@ -23,24 +23,18 @@ DEFAULT_EXTRACTORS = {
 }
 
 
-class ExtractionError(BaseException):
-    """Exceptions thrown in this module's methods"""
-
-
 def _find_7z_by_registry():
     """
     Return a string to 7-zip's 7z.exe from the Windows Registry.
-
-    Raises ExtractionError if it fails.
     """
-    import winreg #pylint: disable=import-error
+    import winreg #pylint: disable=import-error, import-outside-toplevel
     sub_key_7zfm = 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\7zFM.exe'
     try:
         with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, sub_key_7zfm) as key_handle:
             sevenzipfm_dir = winreg.QueryValueEx(key_handle, 'Path')[0]
     except OSError:
         get_logger().exception('Unable to locate 7-zip from the Windows Registry')
-        raise ExtractionError()
+        raise
     sevenzip_path = Path(sevenzipfm_dir, '7z.exe')
     if not sevenzip_path.is_file():
         get_logger().error('7z.exe not found at path from registry: %s', sevenzip_path)
@@ -50,17 +44,15 @@ def _find_7z_by_registry():
 def _find_winrar_by_registry():
     """
     Return a string to WinRAR's WinRAR.exe from the Windows Registry.
-
-    Raises ExtractionError if it fails.
     """
-    import winreg #pylint: disable=import-error
+    import winreg #pylint: disable=import-error, import-outside-toplevel
     sub_key_winrar = 'SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\App Paths\\WinRAR.exe'
     try:
         with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, sub_key_winrar) as key_handle:
             winrar_dir = winreg.QueryValueEx(key_handle, 'Path')[0]
     except OSError:
         get_logger().exception('Unable to locale WinRAR from the Windows Registry')
-        raise ExtractionError()
+        raise
     winrar_path = Path(winrar_dir, 'WinRAR.exe')
     if not winrar_path.is_file():
         get_logger().error('WinRAR.exe not found at path from registry: %s', winrar_path)
@@ -89,7 +81,7 @@ def _process_relative_to(unpack_root, relative_to):
     if not relative_root.is_dir():
         get_logger().error('Could not find relative_to directory in extracted files: %s',
                            relative_to)
-        raise ExtractionError()
+        raise Exception()
     for src_path in relative_root.iterdir():
         dest_path = unpack_root / src_path.name
         src_path.rename(dest_path)
@@ -101,7 +93,7 @@ def _extract_tar_with_7z(binary, archive_path, output_dir, relative_to, skip_unu
     if not relative_to is None and (output_dir / relative_to).exists():
         get_logger().error('Temporary unpacking directory already exists: %s',
                            output_dir / relative_to)
-        raise ExtractionError()
+        raise Exception()
     cmd1 = (binary, 'x', str(archive_path), '-so')
     cmd2 = (binary, 'x', '-si', '-aoa', '-ttar', '-o{}'.format(str(output_dir)))
     if skip_unused:
@@ -117,7 +109,7 @@ def _extract_tar_with_7z(binary, archive_path, output_dir, relative_to, skip_unu
         get_logger().error('7z commands returned non-zero status: %s', proc2.returncode)
         get_logger().debug('stdout: %s', stdout_data)
         get_logger().debug('stderr: %s', stderr_data)
-        raise ExtractionError()
+        raise Exception()
 
     _process_relative_to(output_dir, relative_to)
 
@@ -130,10 +122,10 @@ def _extract_tar_with_tar(binary, archive_path, output_dir, relative_to, skip_un
         for cpath in CONTINGENT_PATHS:
             cmd += ('--exclude=%s/%s' % (str(relative_to), cpath[:-1]), )
     get_logger().debug('tar command line: %s', ' '.join(cmd))
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, check=False)
     if result.returncode != 0:
         get_logger().error('tar command returned %s', result.returncode)
-        raise ExtractionError()
+        raise Exception()
 
     # for gnu tar, the --transform option could be used. but to keep compatibility with
     # bsdtar on macos, we just do this ourselves
@@ -146,12 +138,12 @@ def _extract_tar_with_winrar(binary, archive_path, output_dir, relative_to, skip
     cmd = (binary, 'x', '-o+', str(archive_path), str(output_dir))
     if skip_unused:
         for cpath in CONTINGENT_PATHS:
-            cmd += ('-x%s%s%s' % (str(relative_to), os.sep, cpath[:-1].replace('/'), os.sep), )
+            cmd += ('-x%s%s%s' % (str(relative_to), os.sep, cpath[:-1].replace('/')), )
     get_logger().debug('WinRAR command line: %s', ' '.join(cmd))
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, check=False)
     if result.returncode != 0:
         get_logger().error('WinRAR command returned %s', result.returncode)
-        raise ExtractionError()
+        raise Exception()
 
     _process_relative_to(output_dir, relative_to)
 
@@ -177,7 +169,7 @@ def _extract_tar_with_python(archive_path, output_dir, relative_to, skip_unused)
     except BaseException:
         # Unexpected exception
         get_logger().exception('Unexpected exception during symlink support check.')
-        raise ExtractionError()
+        raise
 
     with tarfile.open(str(archive_path), 'r|%s' % archive_path.suffix[1:]) as tar_file_obj:
         tar_file_obj.members = NoAppendList()
@@ -208,7 +200,7 @@ def _extract_tar_with_python(archive_path, output_dir, relative_to, skip_unused)
                 tar_file_obj._extract_member(tarinfo, str(destination)) # pylint: disable=protected-access
             except BaseException:
                 get_logger().exception('Exception thrown for tar member: %s', tarinfo.name)
-                raise ExtractionError()
+                raise
 
 
 def extract_tar_file(archive_path, output_dir, relative_to, skip_unused, extractors=None):
@@ -222,8 +214,6 @@ def extract_tar_file(archive_path, output_dir, relative_to, skip_unused, extract
         root of the archive, or None if no path components should be stripped.
     extractors is a dictionary of PlatformEnum to a command or path to the
         extractor binary. Defaults to 'tar' for tar, and '_use_registry' for 7-Zip and WinRAR.
-
-    Raises ExtractionError if unexpected issues arise during unpacking.
     """
     if extractors is None:
         extractors = DEFAULT_EXTRACTORS
@@ -279,8 +269,6 @@ def extract_with_7z(
     root of the archive.
     extractors is a dictionary of PlatformEnum to a command or path to the
     extractor binary. Defaults to 'tar' for tar, and '_use_registry' for 7-Zip.
-
-    Raises ExtractionError if unexpected issues arise during unpacking.
     """
     # TODO: It would be nice to extend this to support arbitrary standard IO chaining of 7z
     # instances, so _extract_tar_with_7z and other future formats could use this.
@@ -290,24 +278,24 @@ def extract_with_7z(
     if sevenzip_cmd == USE_REGISTRY:
         if not get_running_platform() == PlatformEnum.WINDOWS:
             get_logger().error('"%s" for 7-zip is only available on Windows', sevenzip_cmd)
-            raise ExtractionError()
+            raise Exception()
         sevenzip_cmd = str(_find_7z_by_registry())
     sevenzip_bin = _find_extractor_by_cmd(sevenzip_cmd)
 
     if not relative_to is None and (output_dir / relative_to).exists():
         get_logger().error('Temporary unpacking directory already exists: %s',
                            output_dir / relative_to)
-        raise ExtractionError()
+        raise Exception()
     cmd = (sevenzip_bin, 'x', str(archive_path), '-aoa', '-o{}'.format(str(output_dir)))
     if skip_unused:
         for cpath in CONTINGENT_PATHS:
             cmd += ('-x!%s/%s' % (str(relative_to), cpath[:-1]), )
     get_logger().debug('7z command line: %s', ' '.join(cmd))
 
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, check=False)
     if result.returncode != 0:
         get_logger().error('7z command returned %s', result.returncode)
-        raise ExtractionError()
+        raise Exception()
 
     _process_relative_to(output_dir, relative_to)
 
@@ -329,8 +317,6 @@ def extract_with_winrar(
     root of the archive.
     extractors is a dictionary of PlatformEnum to a command or path to the
     extractor binary. Defaults to 'tar' for tar, and '_use_registry' for WinRAR.
-
-    Raises ExtractionError if unexpected issues arise during unpacking.
     """
     if extractors is None:
         extractors = DEFAULT_EXTRACTORS
@@ -338,23 +324,23 @@ def extract_with_winrar(
     if winrar_cmd == USE_REGISTRY:
         if not get_running_platform() == PlatformEnum.WINDOWS:
             get_logger().error('"%s" for WinRAR is only available on Windows', winrar_cmd)
-            raise ExtractionError()
+            raise Exception()
         winrar_cmd = str(_find_winrar_by_registry())
     winrar_bin = _find_extractor_by_cmd(winrar_cmd)
 
     if not relative_to is None and (output_dir / relative_to).exists():
         get_logger().error('Temporary unpacking directory already exists: %s',
                            output_dir / relative_to)
-        raise ExtractionError()
+        raise Exception()
     cmd = (winrar_bin, 'x', '-o+', str(archive_path), str(output_dir))
     if skip_unused:
         for cpath in CONTINGENT_PATHS:
             cmd += ('-x%s%s%s' % (str(relative_to), os.sep, cpath[:-1].replace('/', os.sep)), )
     get_logger().debug('WinRAR command line: %s', ' '.join(cmd))
 
-    result = subprocess.run(cmd)
+    result = subprocess.run(cmd, check=False)
     if result.returncode != 0:
         get_logger().error('WinRAR command returned %s', result.returncode)
-        raise ExtractionError()
+        raise Exception()
 
     _process_relative_to(output_dir, relative_to)

--- a/utils/clone.py
+++ b/utils/clone.py
@@ -10,7 +10,7 @@ Module for cloning the source tree.
 
 import sys
 from argparse import ArgumentParser
-from os import chdir, environ, pathsep
+from os import environ, pathsep
 from pathlib import Path
 from shutil import copytree, copy, move
 from stat import S_IWRITE
@@ -44,226 +44,221 @@ target_cpu_only = True;
 """
 
 
-def clone(args):
+def clone(args): # pylint: disable=too-many-branches, too-many-statements
     """Clones, downloads, and generates the required sources"""
-    try:
-        get_logger().info('Setting up cloning environment')
-        iswin = sys.platform.startswith('win')
-        chromium_version = get_chromium_version()
-        ucstaging = args.output / 'uc_staging'
-        dtpath = ucstaging / 'depot_tools'
-        gnpath = ucstaging / 'gn'
-        environ['GCLIENT_FILE'] = str(ucstaging / '.gclient')
-        environ['PATH'] += pathsep + str(dtpath)
-        environ['PYTHONPATH'] = str(dtpath)
-        # Prevent gclient from auto updating depot_tools
-        environ['DEPOT_TOOLS_UPDATE'] = '0'
-        # Don't generate pycache files
-        environ['PYTHONDONTWRITEBYTECODE'] = '1'
-        # Allow usage of system python
-        environ['VPYTHON_BYPASS'] = 'manually managed python not supported by chrome operations'
+    get_logger().info('Setting up cloning environment')
+    iswin = sys.platform.startswith('win')
+    chromium_version = get_chromium_version()
+    ucstaging = args.output / 'uc_staging'
+    dtpath = ucstaging / 'depot_tools'
+    gnpath = ucstaging / 'gn'
+    environ['GCLIENT_FILE'] = str(ucstaging / '.gclient')
+    environ['PATH'] += pathsep + str(dtpath)
+    environ['PYTHONPATH'] = str(dtpath)
+    # Prevent gclient from auto updating depot_tools
+    environ['DEPOT_TOOLS_UPDATE'] = '0'
+    # Don't generate pycache files
+    environ['PYTHONDONTWRITEBYTECODE'] = '1'
+    # Allow usage of system python
+    environ['VPYTHON_BYPASS'] = 'manually managed python not supported by chrome operations'
 
-        # depth=2 since generating LASTCHANGE and gpu_lists_version.h require at least two commits
-        get_logger().info('Cloning chromium source: ' + chromium_version)
-        if (args.output / '.git').exists():
-            run(['git', 'clean', '-fdx'], cwd=args.output, check=True)
-            run(['git', 'fetch', 'origin', 'tag', chromium_version, '--depth=2'],
-                cwd=args.output,
-                check=True)
-            run(['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=args.output, check=True)
-        else:
-            run([
-                'git', 'clone', '-c', 'advice.detachedHead=false', '-b', chromium_version,
-                '--depth=2', "https://chromium.googlesource.com/chromium/src",
-                str(args.output)
-            ],
-                check=True)
-
-        # Set up staging directory
-        ucstaging.mkdir(exist_ok=True)
-
-        get_logger().info('Cloning depot_tools')
-        if dtpath.exists():
-            run(['git', 'clean', '-fdx'], cwd=dtpath, check=True)
-            run(['git', 'fetch', '--depth=1'], cwd=dtpath, check=True)
-            run(['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=dtpath, check=True)
-        else:
-            run([
-                'git', 'clone', '--depth=1',
-                "https://chromium.googlesource.com/chromium/tools/depot_tools",
-                str(dtpath)
-            ],
-                check=True)
-        if iswin:
-            (dtpath / 'git.bat').write_text('git')
-        # Apply changes to gclient
-        run(['git', 'apply'],
-            input=Path(__file__).with_name('depot_tools.patch').read_text().replace(
-                'UC_OUT', str(args.output)).replace('UC_STAGING', str(ucstaging)),
-            cwd=dtpath,
-            check=True,
-            universal_newlines=True)
-
-        # gn requires full history to be able to generate last_commit_position.h
-        get_logger().info('Cloning gn')
-        if gnpath.exists():
-            run(['git', 'clean', '-fdx'], cwd=gnpath, check=True)
-            run(['git', 'fetch'], cwd=gnpath, check=True)
-            run(['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=gnpath, check=True)
-        else:
-            run(['git', 'clone', "https://gn.googlesource.com/gn", str(gnpath)], check=True)
-
-        get_logger().info('Running gsync')
-        if args.custom_config:
-            copy(args.custom_config, ucstaging / '.gclient').replace('UC_OUT', str(args.output))
-        else:
-            (ucstaging / '.gclient').write_text(GC_CONFIG.replace('UC_OUT', str(args.output)))
-        gcpath = dtpath / 'gclient'
-        if iswin:
-            gcpath = gcpath.with_suffix('.bat')
-        # -f, -D, and -R forces a hard reset on changes and deletes deps that have been removed
-        run([str(gcpath), 'sync', '-f', '-D', '-R', '--no-history', '--nohooks'], check=True)
-
-        # Follow tarball procedure:
-        # https://source.chromium.org/chromium/chromium/tools/build/+/main:recipes/recipes/publish_tarball.py
-        get_logger().info('Downloading node modules')
+    # depth=2 since generating LASTCHANGE and gpu_lists_version.h require at least two commits
+    get_logger().info('Cloning chromium source: %s', chromium_version)
+    if (args.output / '.git').exists():
+        run(['git', 'clean', '-fdx'], cwd=args.output, check=True)
+        run(['git', 'fetch', 'origin', 'tag', chromium_version, '--depth=2'],
+            cwd=args.output,
+            check=True)
+        run(['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=args.output, check=True)
+    else:
         run([
-            sys.executable,
-            str(dtpath / 'download_from_google_storage.py'), '--no_resume', '--extract',
-            '--no_auth', '--bucket', 'chromium-nodejs', '-s',
-            str(args.output / 'third_party' / 'node' / 'node_modules.tar.gz.sha1')
+            'git', 'clone', '-c', 'advice.detachedHead=false', '-b', chromium_version, '--depth=2',
+            "https://chromium.googlesource.com/chromium/src",
+            str(args.output)
         ],
             check=True)
 
-        get_logger().info('Downloading pgo profiles')
+    # Set up staging directory
+    ucstaging.mkdir(exist_ok=True)
+
+    get_logger().info('Cloning depot_tools')
+    if dtpath.exists():
+        run(['git', 'clean', '-fdx'], cwd=dtpath, check=True)
+        run(['git', 'fetch', '--depth=1'], cwd=dtpath, check=True)
+        run(['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=dtpath, check=True)
+    else:
         run([
-            sys.executable,
-            str(args.output / 'tools' / 'update_pgo_profiles.py'), '--target=' + args.pgo, 'update',
-            '--gs-url-base=chromium-optimization-profiles/pgo_profiles'
-        ],
-            check=True)
-        # https://chromium-review.googlesource.com/c/chromium/tools/build/+/4380399
-        run([
-            sys.executable,
-            str(args.output / 'v8' / 'tools' / 'builtins-pgo' / 'download_profiles.py'), 'download',
-            '--depot-tools',
+            'git', 'clone', '--depth=1',
+            "https://chromium.googlesource.com/chromium/tools/depot_tools",
             str(dtpath)
         ],
             check=True)
+    if iswin:
+        (dtpath / 'git.bat').write_text('git')
+    # Apply changes to gclient
+    run(['git', 'apply'],
+        input=Path(__file__).with_name('depot_tools.patch').read_text().replace(
+            'UC_OUT', str(args.output)).replace('UC_STAGING', str(ucstaging)),
+        cwd=dtpath,
+        check=True,
+        universal_newlines=True)
 
-        get_logger().info('Generating: DAWN_VERSION')
-        run([
-            sys.executable,
-            str(args.output / 'build' / 'util' / 'lastchange.py'), '-s',
-            str(args.output / 'third_party' / 'dawn'), '--revision',
-            str(args.output / 'gpu' / 'webgpu' / 'DAWN_VERSION')
-        ],
-            check=True)
+    # gn requires full history to be able to generate last_commit_position.h
+    get_logger().info('Cloning gn')
+    if gnpath.exists():
+        run(['git', 'clean', '-fdx'], cwd=gnpath, check=True)
+        run(['git', 'fetch'], cwd=gnpath, check=True)
+        run(['git', 'reset', '--hard', 'FETCH_HEAD'], cwd=gnpath, check=True)
+    else:
+        run(['git', 'clone', "https://gn.googlesource.com/gn", str(gnpath)], check=True)
 
-        get_logger().info('Generating: LASTCHANGE')
-        run([
-            sys.executable,
-            str(args.output / 'build' / 'util' / 'lastchange.py'), '-o',
-            str(args.output / 'build' / 'util' / 'LASTCHANGE')
-        ],
-            check=True)
+    get_logger().info('Running gsync')
+    if args.custom_config:
+        copy(args.custom_config, ucstaging / '.gclient').replace('UC_OUT', str(args.output))
+    else:
+        (ucstaging / '.gclient').write_text(GC_CONFIG.replace('UC_OUT', str(args.output)))
+    gcpath = dtpath / 'gclient'
+    if iswin:
+        gcpath = gcpath.with_suffix('.bat')
+    # -f, -D, and -R forces a hard reset on changes and deletes deps that have been removed
+    run([str(gcpath), 'sync', '-f', '-D', '-R', '--no-history', '--nohooks'], check=True)
 
-        get_logger().info('Generating: gpu_lists_version.h')
-        run([
-            sys.executable,
-            str(args.output / 'build' / 'util' / 'lastchange.py'), '-m', 'GPU_LISTS_VERSION',
-            '--revision-id-only', '--header',
-            str(args.output / 'gpu' / 'config' / 'gpu_lists_version.h')
-        ],
-            check=True)
+    # Follow tarball procedure:
+    # https://source.chromium.org/chromium/chromium/tools/build/+/main:recipes/recipes/publish_tarball.py
+    get_logger().info('Downloading node modules')
+    run([
+        sys.executable,
+        str(dtpath / 'download_from_google_storage.py'), '--no_resume', '--extract', '--no_auth',
+        '--bucket', 'chromium-nodejs', '-s',
+        str(args.output / 'third_party' / 'node' / 'node_modules.tar.gz.sha1')
+    ],
+        check=True)
 
-        get_logger().info('Generating: skia_commit_hash.h')
-        run([
-            sys.executable,
-            str(args.output / 'build' / 'util' / 'lastchange.py'), '-m', 'SKIA_COMMIT_HASH', '-s',
-            str(args.output / 'third_party' / 'skia'), '--header',
-            str(args.output / 'skia' / 'ext' / 'skia_commit_hash.h')
-        ],
-            check=True)
+    get_logger().info('Downloading pgo profiles')
+    run([
+        sys.executable,
+        str(args.output / 'tools' / 'update_pgo_profiles.py'), '--target=' + args.pgo, 'update',
+        '--gs-url-base=chromium-optimization-profiles/pgo_profiles'
+    ],
+        check=True)
+    # https://chromium-review.googlesource.com/c/chromium/tools/build/+/4380399
+    run([
+        sys.executable,
+        str(args.output / 'v8' / 'tools' / 'builtins-pgo' / 'download_profiles.py'), 'download',
+        '--depot-tools',
+        str(dtpath)
+    ],
+        check=True)
 
-        get_logger().info('Generating: last_commit_position.h')
-        run([sys.executable, str(gnpath / 'build' / 'gen.py')], check=True)
-        for item in gnpath.iterdir():
-            if not item.is_dir():
-                copy(item, args.output / 'tools' / 'gn')
-            elif item.name != '.git' and item.name != 'out':
-                copytree(item, args.output / 'tools' / 'gn' / item.name)
-        move(str(gnpath / 'out' / 'last_commit_position.h'),
-             str(args.output / 'tools' / 'gn' / 'bootstrap'))
+    get_logger().info('Generating: DAWN_VERSION')
+    run([
+        sys.executable,
+        str(args.output / 'build' / 'util' / 'lastchange.py'), '-s',
+        str(args.output / 'third_party' / 'dawn'), '--revision',
+        str(args.output / 'gpu' / 'webgpu' / 'DAWN_VERSION')
+    ],
+        check=True)
 
-        get_logger().info('Removing uneeded files')
-        # Match removals for the tarball:
-        # https://source.chromium.org/chromium/chromium/tools/build/+/main:recipes/recipe_modules/chromium/resources/export_tarball.py
-        remove_dirs = (
-            (args.output / 'chrome' / 'test' / 'data'),
-            (args.output / 'content' / 'test' / 'data'),
-            (args.output / 'courgette' / 'testdata'),
-            (args.output / 'extensions' / 'test' / 'data'),
-            (args.output / 'media' / 'test' / 'data'),
-            (args.output / 'native_client' / 'src' / 'trusted' / 'service_runtime' / 'testdata'),
-            (args.output / 'third_party' / 'blink' / 'tools'),
-            (args.output / 'third_party' / 'blink' / 'web_tests'),
-            (args.output / 'third_party' / 'breakpad' / 'breakpad' / 'src' / 'processor' /
-             'testdata'),
-            (args.output / 'third_party' / 'catapult' / 'tracing' / 'test_data'),
-            (args.output / 'third_party' / 'hunspell' / 'tests'),
-            (args.output / 'third_party' / 'hunspell_dictionaries'),
-            (args.output / 'third_party' / 'jdk' / 'current'),
-            (args.output / 'third_party' / 'jdk' / 'extras'),
-            (args.output / 'third_party' / 'liblouis' / 'src' / 'tests' / 'braille-specs'),
-            (args.output / 'third_party' / 'xdg-utils' / 'tests'),
-            (args.output / 'v8' / 'test'),
-        )
-        keep_files = (
-            (args.output / 'chrome' / 'test' / 'data' / 'webui' / 'i18n_process_css_test.html'),
-            (args.output / 'chrome' / 'test' / 'data' / 'webui' / 'mojo' / 'foobar.mojom'),
-            (args.output / 'chrome' / 'test' / 'data' / 'webui' / 'web_ui_test.mojom'),
-            (args.output / 'v8' / 'test' / 'torque' / 'test-torque.tq'),
-        )
-        keep_suffix = ('.gn', '.gni', '.grd', '.gyp', '.isolate', '.pydeps')
-        # Include Contingent Paths
-        for cpath in CONTINGENT_PATHS:
-            remove_dirs += (args.output / Path(cpath), )
-        for remove_dir in remove_dirs:
-            for path in sorted(remove_dir.rglob('*'), key=lambda l: len(str(l)), reverse=True):
-                if path.is_file() and path not in keep_files and path.suffix not in keep_suffix:
-                    try:
-                        path.unlink()
-                    # read-only files can't be deleted on Windows
-                    # so remove the flag and try again.
-                    except PermissionError:
-                        path.chmod(S_IWRITE)
-                        path.unlink()
-                elif path.is_dir() and not any(path.iterdir()):
-                    try:
-                        path.rmdir()
-                    except PermissionError:
-                        path.chmod(S_IWRITE)
-                        path.rmdir()
-        for path in sorted(args.output.rglob('*'), key=lambda l: len(str(l)), reverse=True):
-            if not path.is_symlink() and '.git' not in path.parts:
-                if path.is_file() and ('out' in path.parts or path.name.startswith('ChangeLog')):
-                    try:
-                        path.unlink()
-                    except PermissionError:
-                        path.chmod(S_IWRITE)
-                        path.unlink()
-                elif path.is_dir() and not any(path.iterdir()):
-                    try:
-                        path.rmdir()
-                    except PermissionError:
-                        path.chmod(S_IWRITE)
-                        path.rmdir()
+    get_logger().info('Generating: LASTCHANGE')
+    run([
+        sys.executable,
+        str(args.output / 'build' / 'util' / 'lastchange.py'), '-o',
+        str(args.output / 'build' / 'util' / 'LASTCHANGE')
+    ],
+        check=True)
 
-        get_logger().info('Source cloning complete')
-    except:
-        raise
-        sys.exit(1)
+    get_logger().info('Generating: gpu_lists_version.h')
+    run([
+        sys.executable,
+        str(args.output / 'build' / 'util' / 'lastchange.py'), '-m', 'GPU_LISTS_VERSION',
+        '--revision-id-only', '--header',
+        str(args.output / 'gpu' / 'config' / 'gpu_lists_version.h')
+    ],
+        check=True)
+
+    get_logger().info('Generating: skia_commit_hash.h')
+    run([
+        sys.executable,
+        str(args.output / 'build' / 'util' / 'lastchange.py'), '-m', 'SKIA_COMMIT_HASH', '-s',
+        str(args.output / 'third_party' / 'skia'), '--header',
+        str(args.output / 'skia' / 'ext' / 'skia_commit_hash.h')
+    ],
+        check=True)
+
+    get_logger().info('Generating: last_commit_position.h')
+    run([sys.executable, str(gnpath / 'build' / 'gen.py')], check=True)
+    for item in gnpath.iterdir():
+        if not item.is_dir():
+            copy(item, args.output / 'tools' / 'gn')
+        elif item.name != '.git' and item.name != 'out':
+            copytree(item, args.output / 'tools' / 'gn' / item.name)
+    move(str(gnpath / 'out' / 'last_commit_position.h'),
+         str(args.output / 'tools' / 'gn' / 'bootstrap'))
+
+    get_logger().info('Removing uneeded files')
+    # Match removals for the tarball:
+    # https://source.chromium.org/chromium/chromium/tools/build/+/main:recipes/recipe_modules/chromium/resources/export_tarball.py
+    remove_dirs = (
+        (args.output / 'chrome' / 'test' / 'data'),
+        (args.output / 'content' / 'test' / 'data'),
+        (args.output / 'courgette' / 'testdata'),
+        (args.output / 'extensions' / 'test' / 'data'),
+        (args.output / 'media' / 'test' / 'data'),
+        (args.output / 'native_client' / 'src' / 'trusted' / 'service_runtime' / 'testdata'),
+        (args.output / 'third_party' / 'blink' / 'tools'),
+        (args.output / 'third_party' / 'blink' / 'web_tests'),
+        (args.output / 'third_party' / 'breakpad' / 'breakpad' / 'src' / 'processor' / 'testdata'),
+        (args.output / 'third_party' / 'catapult' / 'tracing' / 'test_data'),
+        (args.output / 'third_party' / 'hunspell' / 'tests'),
+        (args.output / 'third_party' / 'hunspell_dictionaries'),
+        (args.output / 'third_party' / 'jdk' / 'current'),
+        (args.output / 'third_party' / 'jdk' / 'extras'),
+        (args.output / 'third_party' / 'liblouis' / 'src' / 'tests' / 'braille-specs'),
+        (args.output / 'third_party' / 'xdg-utils' / 'tests'),
+        (args.output / 'v8' / 'test'),
+    )
+    keep_files = (
+        (args.output / 'chrome' / 'test' / 'data' / 'webui' / 'i18n_process_css_test.html'),
+        (args.output / 'chrome' / 'test' / 'data' / 'webui' / 'mojo' / 'foobar.mojom'),
+        (args.output / 'chrome' / 'test' / 'data' / 'webui' / 'web_ui_test.mojom'),
+        (args.output / 'v8' / 'test' / 'torque' / 'test-torque.tq'),
+    )
+    keep_suffix = ('.gn', '.gni', '.grd', '.gyp', '.isolate', '.pydeps')
+    # Include Contingent Paths
+    for cpath in CONTINGENT_PATHS:
+        remove_dirs += (args.output / Path(cpath), )
+    for remove_dir in remove_dirs:
+        for path in sorted(remove_dir.rglob('*'), key=lambda l: len(str(l)), reverse=True):
+            if path.is_file() and path not in keep_files and path.suffix not in keep_suffix:
+                try:
+                    path.unlink()
+                # read-only files can't be deleted on Windows
+                # so remove the flag and try again.
+                except PermissionError:
+                    path.chmod(S_IWRITE)
+                    path.unlink()
+            elif path.is_dir() and not any(path.iterdir()):
+                try:
+                    path.rmdir()
+                except PermissionError:
+                    path.chmod(S_IWRITE)
+                    path.rmdir()
+    for path in sorted(args.output.rglob('*'), key=lambda l: len(str(l)), reverse=True):
+        if not path.is_symlink() and '.git' not in path.parts:
+            if path.is_file() and ('out' in path.parts or path.name.startswith('ChangeLog')):
+                try:
+                    path.unlink()
+                except PermissionError:
+                    path.chmod(S_IWRITE)
+                    path.unlink()
+            elif path.is_dir() and not any(path.iterdir()):
+                try:
+                    path.rmdir()
+                except PermissionError:
+                    path.chmod(S_IWRITE)
+                    path.rmdir()
+
+    get_logger().info('Source cloning complete')
 
 
 def main():

--- a/utils/clone.py
+++ b/utils/clone.py
@@ -193,9 +193,8 @@ def clone(args):
                 copy(item, args.output / 'tools' / 'gn')
             elif item.name != '.git' and item.name != 'out':
                 copytree(item, args.output / 'tools' / 'gn' / item.name)
-        move(
-            str(gnpath / 'out' / 'last_commit_position.h'),
-            str(args.output / 'tools' / 'gn' / 'bootstrap'))
+        move(str(gnpath / 'out' / 'last_commit_position.h'),
+             str(args.output / 'tools' / 'gn' / 'bootstrap'))
 
         get_logger().info('Removing uneeded files')
         # Match removals for the tarball:
@@ -270,25 +269,22 @@ def clone(args):
 def main():
     """CLI Entrypoint"""
     parser = ArgumentParser(description=__doc__)
-    parser.add_argument(
-        '-o',
-        '--output',
-        type=Path,
-        metavar='DIRECTORY',
-        default='chromium',
-        help='Output directory for the cloned sources. Default: %(default)s')
-    parser.add_argument(
-        '-c',
-        '--custom-config',
-        type=Path,
-        metavar='FILE',
-        help='Supply a replacement for the default gclient config.')
-    parser.add_argument(
-        '-p',
-        '--pgo',
-        default='linux',
-        choices=('linux', 'mac', 'mac-arm', 'win32', 'win64'),
-        help='Specifiy which pgo profile to download.  Default: %(default)s')
+    parser.add_argument('-o',
+                        '--output',
+                        type=Path,
+                        metavar='DIRECTORY',
+                        default='chromium',
+                        help='Output directory for the cloned sources. Default: %(default)s')
+    parser.add_argument('-c',
+                        '--custom-config',
+                        type=Path,
+                        metavar='FILE',
+                        help='Supply a replacement for the default gclient config.')
+    parser.add_argument('-p',
+                        '--pgo',
+                        default='linux',
+                        choices=('linux', 'mac', 'mac-arm', 'win32', 'win64'),
+                        help='Specifiy which pgo profile to download.  Default: %(default)s')
     add_common_params(parser)
     args = parser.parse_args()
     clone(args)

--- a/utils/depot_tools.patch
+++ b/utils/depot_tools.patch
@@ -2,11 +2,10 @@
 #   move dotfiles into the staging directory
 #   skip cipd binary downloads
 #   replace 'src' in checkout paths with the output directory
-#   fixes functools decorators for older python
 #   ensure shallow fetches
 --- a/gclient.py
 +++ b/gclient.py
-@@ -121,8 +121,8 @@ DEPOT_TOOLS_DIR = os.path.dirname(os.pat
+@@ -126,8 +126,8 @@ DEPOT_TOOLS_DIR = os.path.dirname(os.pat
  # one, e.g. if a spec explicitly says `cache_dir = None`.)
  UNSET_CACHE_DIR = object()
  
@@ -17,7 +16,7 @@
  
  PREVIOUS_SYNC_COMMITS = 'GCLIENT_PREVIOUS_SYNC_COMMITS'
  
-@@ -417,6 +417,7 @@ class Dependency(gclient_utils.WorkItem,
+@@ -422,6 +422,7 @@ class Dependency(gclient_utils.WorkItem,
                   protocol='https',
                   git_dependencies_state=gclient_eval.DEPS,
                   print_outbuf=False):
@@ -25,7 +24,7 @@
          gclient_utils.WorkItem.__init__(self, name)
          DependencySettings.__init__(self, parent, url, managed, custom_deps,
                                      custom_vars, custom_hooks, deps_file,
-@@ -725,6 +726,7 @@ class Dependency(gclient_utils.WorkItem,
+@@ -730,6 +731,7 @@ class Dependency(gclient_utils.WorkItem,
  
              condition = dep_value.get('condition')
              dep_type = dep_value.get('dep_type')
@@ -33,7 +32,7 @@
  
              if condition and not self._get_option('process_all_deps', False):
                  if condition not in cached_conditions:
-@@ -828,6 +830,8 @@ class Dependency(gclient_utils.WorkItem,
+@@ -846,6 +848,8 @@ class Dependency(gclient_utils.WorkItem,
  
          self._gn_args_from = local_scope.get('gclient_gn_args_from')
          self._gn_args_file = local_scope.get('gclient_gn_args_file')
@@ -42,47 +41,9 @@
          self._gn_args = local_scope.get('gclient_gn_args', [])
          # It doesn't make sense to set all of these, since setting gn_args_from
          # to another DEPS will make gclient ignore any other local gn_args*
---- a/gclient_paths.py
-+++ b/gclient_paths.py
-@@ -20,7 +20,7 @@ import subprocess2
- # pylint: disable=line-too-long
- 
- 
--@functools.lru_cache
-+@functools.lru_cache()
- def FindGclientRoot(from_dir, filename='.gclient'):
-     """Tries to find the gclient root."""
-     real_from_dir = os.path.abspath(from_dir)
-@@ -67,7 +67,7 @@ def FindGclientRoot(from_dir, filename='
-     return None
- 
- 
--@functools.lru_cache
-+@functools.lru_cache()
- def _GetPrimarySolutionPathInternal(cwd):
-     gclient_root = FindGclientRoot(cwd)
-     if gclient_root:
-@@ -96,7 +96,7 @@ def GetPrimarySolutionPath():
-     return _GetPrimarySolutionPathInternal(os.getcwd())
- 
- 
--@functools.lru_cache
-+@functools.lru_cache()
- def _GetBuildtoolsPathInternal(cwd, override):
-     if override is not None:
-         return override
-@@ -151,7 +151,7 @@ def GetExeSuffix():
-     return ''
- 
- 
--@functools.lru_cache
-+@functools.lru_cache()
- def GetGClientPrimarySolutionName(gclient_root_dir_path):
-     """Returns the name of the primary solution in the .gclient file specified."""
-     gclient_config_file = os.path.join(gclient_root_dir_path, '.gclient')
 --- a/gclient_scm.py
 +++ b/gclient_scm.py
-@@ -837,8 +837,7 @@ class GitWrapper(SCMWrapper):
+@@ -844,8 +844,7 @@ class GitWrapper(SCMWrapper):
          self._SetFetchConfig(options)
  
          # Fetch upstream if we don't already have |revision|.
@@ -92,7 +53,7 @@
              self._Fetch(options, prune=options.force)
  
              if not scm.GIT.IsValidRevision(
-@@ -854,7 +853,7 @@ class GitWrapper(SCMWrapper):
+@@ -861,7 +860,7 @@ class GitWrapper(SCMWrapper):
  
          # This is a big hammer, debatable if it should even be here...
          if options.force or options.reset:
@@ -101,7 +62,7 @@
              if options.upstream and upstream_branch:
                  target = upstream_branch
              self._Scrub(target, options)
-@@ -869,7 +868,6 @@ class GitWrapper(SCMWrapper):
+@@ -876,7 +875,6 @@ class GitWrapper(SCMWrapper):
              # to the checkout step.
              if not (options.force or options.reset):
                  self._CheckClean(revision)
@@ -109,7 +70,7 @@
              if self._Capture(['rev-list', '-n', '1', 'HEAD']) == revision:
                  self.Print('Up-to-date; skipping checkout.')
              else:
-@@ -1545,8 +1543,7 @@ class GitWrapper(SCMWrapper):
+@@ -1550,8 +1548,7 @@ class GitWrapper(SCMWrapper):
              fetch_cmd.append('--no-tags')
          elif quiet:
              fetch_cmd.append('--quiet')

--- a/utils/domain_substitution.py
+++ b/utils/domain_substitution.py
@@ -206,9 +206,8 @@ def apply_substitution(regex_path, files_path, source_tree, domainsub_cache):
     resolved_tree = source_tree.resolve()
     regex_pairs = DomainRegexList(regex_path).regex_pairs
     fileindex_content = io.BytesIO()
-    with tarfile.open(
-            str(domainsub_cache), 'w:%s' % domainsub_cache.suffix[1:],
-            compresslevel=1) if domainsub_cache else open(os.devnull, 'w') as cache_tar:
+    with tarfile.open(str(domainsub_cache), 'w:%s' % domainsub_cache.suffix[1:],
+                      compresslevel=1) if domainsub_cache else open(os.devnull, 'w') as cache_tar:
         for relative_path in filter(len, files_path.read_text().splitlines()):
             if _INDEX_HASH_DELIMITER in relative_path:
                 if domainsub_cache:
@@ -281,8 +280,8 @@ def revert_substitution(domainsub_cache, source_tree):
 
     cache_index_files = set() # All files in the file index
 
-    with tempfile.TemporaryDirectory(
-            prefix='domsubcache_files', dir=str(resolved_tree)) as tmp_extract_name:
+    with tempfile.TemporaryDirectory(prefix='domsubcache_files',
+                                     dir=str(resolved_tree)) as tmp_extract_name:
         extract_path = Path(tmp_extract_name)
         get_logger().debug('Extracting domain substitution cache...')
         extract_tar_file(domainsub_cache, extract_path, None, False)
@@ -333,17 +332,24 @@ def main():
         'apply',
         help='Apply domain substitution',
         description='Applies domain substitution and creates the domain substitution cache.')
-    apply_parser.add_argument(
-        '-r', '--regex', type=Path, required=True, help='Path to domain_regex.list')
-    apply_parser.add_argument(
-        '-f', '--files', type=Path, required=True, help='Path to domain_substitution.list')
+    apply_parser.add_argument('-r',
+                              '--regex',
+                              type=Path,
+                              required=True,
+                              help='Path to domain_regex.list')
+    apply_parser.add_argument('-f',
+                              '--files',
+                              type=Path,
+                              required=True,
+                              help='Path to domain_substitution.list')
     apply_parser.add_argument(
         '-c',
         '--cache',
         type=Path,
         help='The path to the domain substitution cache. The path must not already exist.')
-    apply_parser.add_argument(
-        'directory', type=Path, help='The directory to apply domain substitution')
+    apply_parser.add_argument('directory',
+                              type=Path,
+                              help='The directory to apply domain substitution')
     apply_parser.set_defaults(reverting=False)
 
     # revert
@@ -351,15 +357,15 @@ def main():
         'revert',
         help='Revert domain substitution',
         description='Reverts domain substitution based only on the domain substitution cache.')
-    revert_parser.add_argument(
-        'directory', type=Path, help='The directory to reverse domain substitution')
-    revert_parser.add_argument(
-        '-c',
-        '--cache',
-        type=Path,
-        required=True,
-        help=('The path to the domain substitution cache. '
-              'The path must exist and will be removed if successful.'))
+    revert_parser.add_argument('directory',
+                               type=Path,
+                               help='The directory to reverse domain substitution')
+    revert_parser.add_argument('-c',
+                               '--cache',
+                               type=Path,
+                               required=True,
+                               help=('The path to the domain substitution cache. '
+                                     'The path must exist and will be removed if successful.'))
     revert_parser.set_defaults(reverting=True)
 
     args = parser.parse_args()

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -104,7 +104,6 @@ class DownloadInfo: #pylint: disable=too-few-public-methods
 
         Raises schema.SchemaError if validation fails
         """
-
         def _section_generator(data):
             for section in data:
                 if section == configparser.DEFAULTSECT:
@@ -148,13 +147,12 @@ class DownloadInfo: #pylint: disable=too-few-public-methods
 
     def properties_iter(self):
         """Iterator for the download properties sorted by output path"""
-        return sorted(
-            map(lambda x: (x, self[x]), self), key=(lambda x: str(Path(x[1].output_path))))
+        return sorted(map(lambda x: (x, self[x]), self),
+                      key=(lambda x: str(Path(x[1].output_path))))
 
 
 class _UrlRetrieveReportHook: #pylint: disable=too-few-public-methods
     """Hook for urllib.request.urlretrieve to log progress information to console"""
-
     def __init__(self):
         self._max_len_printed = 0
         self._last_percentage = None
@@ -340,12 +338,11 @@ def unpack_downloads(download_info, cache_dir, output_dir, skip_unused, extracto
         else:
             strip_leading_dirs_path = Path(download_properties.strip_leading_dirs)
 
-        extractor_func(
-            archive_path=download_path,
-            output_dir=output_dir / Path(download_properties.output_path),
-            relative_to=strip_leading_dirs_path,
-            skip_unused=skip_unused,
-            extractors=extractors)
+        extractor_func(archive_path=download_path,
+                       output_dir=output_dir / Path(download_properties.output_path),
+                       relative_to=strip_leading_dirs_path,
+                       skip_unused=skip_unused,
+                       extractors=extractors)
 
 
 def _add_common_args(parser):
@@ -355,13 +352,16 @@ def _add_common_args(parser):
         type=Path,
         nargs='+',
         help='The downloads INI to parse for downloads. Can be specified multiple times.')
-    parser.add_argument(
-        '-c', '--cache', type=Path, required=True, help='Path to the directory to cache downloads.')
+    parser.add_argument('-c',
+                        '--cache',
+                        type=Path,
+                        required=True,
+                        help='Path to the directory to cache downloads.')
 
 
 def _retrieve_callback(args):
-    retrieve_downloads(
-        DownloadInfo(args.ini), args.cache, args.show_progress, args.disable_ssl_verification)
+    retrieve_downloads(DownloadInfo(args.ini), args.cache, args.show_progress,
+                       args.disable_ssl_verification)
     try:
         check_downloads(DownloadInfo(args.ini), args.cache)
     except HashMismatchError as exc:
@@ -393,11 +393,10 @@ def main():
                      'If it is not present, Python\'s urllib will be used. However, only '
                      'the CLI-based downloaders can be resumed if the download is aborted.'))
     _add_common_args(retrieve_parser)
-    retrieve_parser.add_argument(
-        '--hide-progress-bar',
-        action='store_false',
-        dest='show_progress',
-        help='Hide the download progress.')
+    retrieve_parser.add_argument('--hide-progress-bar',
+                                 action='store_false',
+                                 dest='show_progress',
+                                 help='Hide the download progress.')
     retrieve_parser.add_argument(
         '--disable-ssl-verification',
         action='store_true',
@@ -410,11 +409,10 @@ def main():
         help='Unpack download files',
         description='Verifies hashes of and unpacks download files into the specified directory.')
     _add_common_args(unpack_parser)
-    unpack_parser.add_argument(
-        '--tar-path',
-        default='tar',
-        help=('(Linux and macOS only) Command or path to the BSD or GNU tar '
-              'binary for extraction. Default: %(default)s'))
+    unpack_parser.add_argument('--tar-path',
+                               default='tar',
+                               help=('(Linux and macOS only) Command or path to the BSD or GNU tar '
+                                     'binary for extraction. Default: %(default)s'))
     unpack_parser.add_argument(
         '--7z-path',
         dest='sevenz_path',
@@ -428,10 +426,9 @@ def main():
         help=('Command or path to WinRAR\'s "winrar" binary. If "_use_registry" is '
               'specified, determine the path from the registry. Default: %(default)s'))
     unpack_parser.add_argument('output', type=Path, help='The directory to unpack to.')
-    unpack_parser.add_argument(
-        '--skip-unused',
-        action='store_true',
-        help='Skip extraction of unused directories (CONTINGENT_PATHS).')
+    unpack_parser.add_argument('--skip-unused',
+                               action='store_true',
+                               help='Skip extraction of unused directories (CONTINGENT_PATHS).')
     unpack_parser.set_defaults(callback=_unpack_callback)
 
     args = parser.parse_args()

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -13,6 +13,7 @@ import configparser
 import enum
 import hashlib
 import shutil
+import ssl
 import subprocess
 import sys
 import urllib.request
@@ -23,7 +24,7 @@ from _common import ENCODING, USE_REGISTRY, ExtractorEnum, get_logger, \
 from _extraction import extract_tar_file, extract_with_7z, extract_with_winrar
 
 sys.path.insert(0, str(Path(__file__).parent / 'third_party'))
-import schema #pylint: disable=wrong-import-position
+import schema #pylint: disable=wrong-import-position, wrong-import-order
 sys.path.pop(0)
 
 # Constants
@@ -31,7 +32,7 @@ sys.path.pop(0)
 
 class HashesURLEnum(str, enum.Enum):
     """Enum for supported hash URL schemes"""
-    chromium = 'chromium'
+    CHROMIUM = 'chromium'
 
 
 class HashMismatchError(BaseException):
@@ -185,7 +186,6 @@ def _download_via_urllib(url, file_path, show_progress, disable_ssl_verification
     if show_progress:
         reporthook = _UrlRetrieveReportHook()
     if disable_ssl_verification:
-        import ssl
         # TODO: Remove this or properly implement disabling SSL certificate verification
         orig_https_context = ssl._create_default_https_context #pylint: disable=protected-access
         ssl._create_default_https_context = ssl._create_unverified_context #pylint: disable=protected-access

--- a/utils/filescfg.py
+++ b/utils/filescfg.py
@@ -11,6 +11,8 @@ Operations with FILES.cfg (for portable packages)
 import argparse
 import platform
 import sys
+import tarfile
+import zipfile
 from pathlib import Path
 
 from _common import get_logger, add_common_params
@@ -52,7 +54,6 @@ def _get_archive_writer(output_path):
     if not output_path.suffixes:
         raise ValueError('Output name has no suffix: %s' % output_path.name)
     if output_path.suffixes[-1].lower() == '.zip':
-        import zipfile
         archive_root = Path(output_path.stem)
         output_archive = zipfile.ZipFile(str(output_path), 'w', zipfile.ZIP_DEFLATED)
 
@@ -65,7 +66,6 @@ def _get_archive_writer(output_path):
             else:
                 output_archive.write(str(in_path), str(arc_path))
     elif '.tar' in output_path.name.lower():
-        import tarfile
         if len(output_path.suffixes) >= 2 and output_path.suffixes[-2].lower() == '.tar':
             tar_mode = 'w:%s' % output_path.suffixes[-1][1:]
             archive_root = Path(output_path.with_suffix('').stem)

--- a/utils/filescfg.py
+++ b/utils/filescfg.py
@@ -60,8 +60,8 @@ def _get_archive_writer(output_path):
             """Add files to zip archive"""
             if in_path.is_dir():
                 for sub_path in in_path.rglob('*'):
-                    output_archive.write(
-                        str(sub_path), str(arc_path / sub_path.relative_to(in_path)))
+                    output_archive.write(str(sub_path),
+                                         str(arc_path / sub_path.relative_to(in_path)))
             else:
                 output_archive.write(str(in_path), str(arc_path))
     elif '.tar' in output_path.name.lower():
@@ -121,37 +121,33 @@ def _archive_callback(args):
     """
     Create an archive of the build outputs. Supports zip and compressed tar archives.
     """
-    create_archive(
-        filescfg_generator(args.cfg, args.build_outputs, args.cpu_arch), args.include,
-        args.build_outputs, args.output)
+    create_archive(filescfg_generator(args.cfg, args.build_outputs, args.cpu_arch), args.include,
+                   args.build_outputs, args.output)
 
 
 def main():
     """CLI Entrypoint"""
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-c',
-        '--cfg',
-        metavar='PATH',
-        type=Path,
-        required=True,
-        help=('The FILES.cfg to use. They are usually located under a '
-              'directory in chrome/tools/build/ of the source tree.'))
-    parser.add_argument(
-        '--build-outputs',
-        metavar='PATH',
-        type=Path,
-        default='out/Default',
-        help=('The path to the build outputs directory relative to the '
-              'source tree. Default: %(default)s'))
-    parser.add_argument(
-        '--cpu-arch',
-        metavar='ARCH',
-        default=platform.architecture()[0],
-        choices=('64bit', '32bit'),
-        help=('Filter build outputs by a target CPU. '
-              'This is the same as the "arch" key in FILES.cfg. '
-              'Default (from platform.architecture()): %(default)s'))
+    parser.add_argument('-c',
+                        '--cfg',
+                        metavar='PATH',
+                        type=Path,
+                        required=True,
+                        help=('The FILES.cfg to use. They are usually located under a '
+                              'directory in chrome/tools/build/ of the source tree.'))
+    parser.add_argument('--build-outputs',
+                        metavar='PATH',
+                        type=Path,
+                        default='out/Default',
+                        help=('The path to the build outputs directory relative to the '
+                              'source tree. Default: %(default)s'))
+    parser.add_argument('--cpu-arch',
+                        metavar='ARCH',
+                        default=platform.architecture()[0],
+                        choices=('64bit', '32bit'),
+                        help=('Filter build outputs by a target CPU. '
+                              'This is the same as the "arch" key in FILES.cfg. '
+                              'Default (from platform.architecture()): %(default)s'))
     add_common_params(parser)
 
     subparsers = parser.add_subparsers(title='filescfg actions')

--- a/utils/make_domsub_script.py
+++ b/utils/make_domsub_script.py
@@ -86,10 +86,16 @@ def main():
     parser.set_defaults(callback=_callback)
 
     parser.add_argument('-r', '--regex', type=Path, required=True, help='Path to domain_regex.list')
-    parser.add_argument(
-        '-f', '--files', type=Path, required=True, help='Path to domain_substitution.list')
-    parser.add_argument(
-        '-o', '--output', type=Path, required=True, help='Path to script file to create')
+    parser.add_argument('-f',
+                        '--files',
+                        type=Path,
+                        required=True,
+                        help='Path to domain_substitution.list')
+    parser.add_argument('-o',
+                        '--output',
+                        type=Path,
+                        required=True,
+                        help='Path to script file to create')
 
     args = parser.parse_args()
     args.callback(args)

--- a/utils/patches.py
+++ b/utils/patches.py
@@ -64,8 +64,10 @@ def find_and_check_patch(patch_bin_path=None):
 
     # Ensure patch actually runs
     cmd = [str(patch_bin_path), '--version']
-    result = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    result = subprocess.run(cmd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            universal_newlines=True)
     if result.returncode:
         get_logger().error('"%s" returned non-zero exit code', ' '.join(cmd))
         get_logger().error('stdout:\n%s', result.stdout)
@@ -92,8 +94,10 @@ def dry_run_check(patch_path, tree_path, patch_bin_path=None):
         str(patch_path), '-d',
         str(tree_path), '--no-backup-if-mismatch', '--dry-run'
     ]
-    result = subprocess.run(
-        cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, universal_newlines=True)
+    result = subprocess.run(cmd,
+                            stdout=subprocess.PIPE,
+                            stderr=subprocess.PIPE,
+                            universal_newlines=True)
     return result.returncode, result.stdout, result.stderr
 
 
@@ -161,8 +165,8 @@ def merge_patches(source_iter, destination, prepend=False):
         if prepend:
             if not (destination / 'series').exists():
                 raise FileNotFoundError(
-                    'Could not find series file in existing destination: {}'.format(
-                        destination / 'series'))
+                    'Could not find series file in existing destination: {}'.format(destination /
+                                                                                    'series'))
             known_paths.update(generate_patches_from_series(destination))
         else:
             raise FileExistsError('destination already exists: {}'.format(destination))
@@ -195,10 +199,9 @@ def _apply_callback(args, parser_error):
                     f'--patch-bin "{args.patch_bin}" is not a command or path to executable.')
     for patch_dir in args.patches:
         logger.info('Applying patches from %s', patch_dir)
-        apply_patches(
-            generate_patches_from_series(patch_dir, resolve=True),
-            args.target,
-            patch_bin_path=patch_bin_path)
+        apply_patches(generate_patches_from_series(patch_dir, resolve=True),
+                      args.target,
+                      patch_bin_path=patch_bin_path)
 
 
 def _merge_callback(args, _):
@@ -213,8 +216,8 @@ def main():
 
     apply_parser = subparsers.add_parser(
         'apply', help='Applies patches (in GNU Quilt format) to the specified source tree')
-    apply_parser.add_argument(
-        '--patch-bin', help='The GNU patch command to use. Omit to find it automatically.')
+    apply_parser.add_argument('--patch-bin',
+                              help='The GNU patch command to use. Omit to find it automatically.')
     apply_parser.add_argument('target', type=Path, help='The directory tree to apply patches onto.')
     apply_parser.add_argument(
         'patches',
@@ -223,8 +226,8 @@ def main():
         help='The directories containing patches to apply. They must be in GNU quilt format')
     apply_parser.set_defaults(callback=_apply_callback)
 
-    merge_parser = subparsers.add_parser(
-        'merge', help='Merges patches directories in GNU quilt format')
+    merge_parser = subparsers.add_parser('merge',
+                                         help='Merges patches directories in GNU quilt format')
     merge_parser.add_argument(
         '--prepend',
         '-p',
@@ -236,8 +239,10 @@ def main():
         type=Path,
         help=('The directory to write the merged patches to. '
               'The destination must not exist unless --prepend is specified.'))
-    merge_parser.add_argument(
-        'source', type=Path, nargs='+', help='The GNU quilt patches to merge.')
+    merge_parser.add_argument('source',
+                              type=Path,
+                              nargs='+',
+                              help='The GNU quilt patches to merge.')
     merge_parser.set_defaults(callback=_merge_callback)
 
     args = parser.parse_args()

--- a/utils/patches.py
+++ b/utils/patches.py
@@ -67,6 +67,7 @@ def find_and_check_patch(patch_bin_path=None):
     result = subprocess.run(cmd,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
+                            check=False,
                             universal_newlines=True)
     if result.returncode:
         get_logger().error('"%s" returned non-zero exit code', ' '.join(cmd))
@@ -97,6 +98,7 @@ def dry_run_check(patch_path, tree_path, patch_bin_path=None):
     result = subprocess.run(cmd,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
+                            check=False,
                             universal_newlines=True)
     return result.returncode, result.stdout, result.stderr
 

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -7,12 +7,12 @@
 """Prune binaries from the source tree"""
 
 import argparse
-from pathlib import Path
-
-from _common import ENCODING, get_logger, add_common_params
 import sys
 import os
 import stat
+from pathlib import Path
+
+from _common import ENCODING, get_logger, add_common_params
 
 # List of paths to prune if they exist, excluded from domain_substitution and pruning lists
 # These allow the lists to be compatible between cloned and tarball sources


### PR DESCRIPTION
This PR updates the Cirrus container to use Debian bullseye with python 3.9 and updates the scripts for these changes.  

I've separated the changes into four commits with the third having the most significant changes:
* Calls to `exit` have been updated to `sys.exit`, subprocess run calls have `check` set, and imports reordered
* The duplicate-code pylint check is disabled in `devutils/run_devutils_pylint.py` since main() has a similar section to `devutils/run_other_pylint.py`, which ironically no longer makes it similar
* The utils path needed to be added in `devutils/run_utils_pylint.py` for local imports to be found in the newer version of python
* The scripts in `devutils/tests` needed to be updated so I took the opportunity to make them usable
* UnusedPatterns in `devutils/update_lists.py` [adds it's members in a loop](https://github.com/ungoogled-software/ungoogled-chromium/blob/88fc9a108bc62e47fcec5c0cf52848e706658d6b/devutils/update_lists.py#L125-L132) which pylint doesn't seem to understand, so the no-member check is disabled for the unused_patterns
* The custom ExtractionError in `utils/_extraction.py` doesn't handle exceptions in any unique way so it has been replaced with regular exceptions
* The try/catch in the clone script has been removed since we weren't doing anything special with the exception anyways.  This might be easier to check out with a diff program that is more indentation-aware

These changes should hopefully allow our tasks to run clones without constant additions.  I have only tested these changes on linux, so it would be nice to have confirmation that everything still works correctly on other platforms.  