### PR TITLE
Tweak platform conditional in patch to support cross builds

### DIFF
--- a/patches/core/ungoogled-chromium/disable-domain-reliability.patch
+++ b/patches/core/ungoogled-chromium/disable-domain-reliability.patch
@@ -86,7 +86,7 @@
 -    "--output",
 -    rebase_path(output_file, root_build_dir),
 -  ]
-+  if (is_win) {
++  if (host_os == "win") {
 +      args = [
 +        "--file-list",
 +        "nul",


### PR DESCRIPTION
In `disable-domain-reliability.patch`, a conditional block is added to allow a script in the `domain_reliability` component to accept a null device as input (`NUL` on Windows, `/dev/null` on Linux).

However, the condition is predicated on `is_win`, which translates to "is this build for Windows?" When I [cross-compile](https://github.com/ungoogled-software/ungoogled-chromium-windows/issues/293) ungoogled-chromium on Linux for Windows, I get this:
```
[1474/66598] ACTION //components/domain_reliability:bake_in_configs(//build/toolchain/win:win_clang_x64)
1757 FAILED: gen/components/domain_reliability/baked_in_configs.cc 
1758 python3 ../../components/domain_reliability/bake_in_configs.py --file-list nul --output gen/components/domain_reliability/baked_in_configs.cc
1759 Traceback (most recent call last):
1760   File "/home/build/u-c-w/cross-build/build/src/out/Default/../../components/domain_reliability/bake_in_configs.py", line 597, in <module>
1761     sys.exit(main())
1762              ^^^^^^
1763   File "/home/build/u-c-w/cross-build/build/src/out/Default/../../components/domain_reliability/bake_in_configs.py", line 549, in main
1764     json_files = read_json_files_from_file(opts.file_list)
1765                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
1766   File "/home/build/u-c-w/cross-build/build/src/out/Default/../../components/domain_reliability/bake_in_configs.py", line 483, in read_json_files_from_file
1767     with open(list_file, 'r') as f:
1768          ^^^^^^^^^^^^^^^^^^^^
1769 FileNotFoundError: [Errno 2] No such file or directory: 'nul'
```

This PR changes the condition to `host_os == "win"` (i.e. "are we building on Windows?"), which I believe is what was intended. This allows the cross build to succeed.