### PR TITLE
[README] Remove openSUSE mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,6 @@ ungoogled-chromium is available in the following **software repositories**:
 * Fedora: Available in [COPR](https://copr.fedorainfracloud.org/coprs/) as [`wojnilowicz/ungoogled-chromium`](https://copr.fedorainfracloud.org/coprs/wojnilowicz/ungoogled-chromium/). Also available in [RPM Fusion](https://rpmfusion.org/Configuration) as `chromium-browser-privacy` (outdated).
 * Gentoo: Available in [`::pf4public`](https://github.com/PF4Public/gentoo-overlay) overlay as [`ungoogled-chromium`](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium) and [`ungoogled-chromium-bin`](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium-bin) ebuilds
 * macOS: Available in [Homebrew](https://brew.sh/) as [`eloston-chromium`](https://formulae.brew.sh/cask/eloston-chromium). Just run `brew install --cask eloston-chromium`. Chromium will appear in your `/Applications` directory.
-* openSUSE: Available in [openSUSE Tumbleweed](https://get.opensuse.org/tumbleweed/), run `zypper in ungoogled-chromium`. See [package site](https://software.opensuse.org/package/ungoogled-chromium) for additional options.
 
 If your GNU/Linux distribution is not listed, there are distro-independent builds available via the following **package managers**:
 


### PR DESCRIPTION
Unfortunately I've stopped maintaining ungoogled-chromium for opensuse as there are talks about opensuse not building chromium at all and frankly I've switched to firefox, though I still love what you guys are doing and support you all the way. 

For more info if you don't want to remove the entry, the devel package (package that's still built on obs but not in the standard repos) will be left alone 
https://build.opensuse.org/package/show/network:chromium/ungoogled-chromium
when someone wants to pick up maintenance they can do so.