### PR TITLE
Safebrowsing fix for mac and win & Disable FedCM functionality

### DIFF
--- a/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
+++ b/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
@@ -1554,6 +1554,30 @@
  
  #if BUILDFLAG(IS_MAC)
    // Do not allow picker UI to be shown on a page that isn't in the foreground
+--- a/chrome/browser/net/profile_network_context_service.cc
++++ b/chrome/browser/net/profile_network_context_service.cc
+@@ -286,20 +286,7 @@ void UpdateCookieSettings(Profile* profi
+ std::unique_ptr<net::ClientCertStore> GetWrappedCertStore(
+     Profile* profile,
+     std::unique_ptr<net::ClientCertStore> platform_store) {
+-  if (!profile || !client_certificates::features::
+-                      IsManagedClientCertificateForUserEnabled()) {
+-    return platform_store;
+-  }
+-
+-  auto* provisioning_service =
+-      client_certificates::CertificateProvisioningServiceFactory::GetForProfile(
+-          profile);
+-  if (!provisioning_service) {
+-    return platform_store;
+-  }
+-
+-  return client_certificates::ClientCertificatesService::Create(
+-      provisioning_service, std::move(platform_store));
++  return nullptr;
+ }
+ #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
+ 
 --- a/chrome/browser/notifications/notification_display_service_impl.cc
 +++ b/chrome/browser/notifications/notification_display_service_impl.cc
 @@ -88,13 +88,6 @@ NotificationDisplayServiceImpl::Notifica

--- a/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
+++ b/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
@@ -6748,3 +6748,37 @@
  // TODO(crbug.com/40904479): Maybe move to chrome_syncable_prefs_database.cc,
  // see bug.
  #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)
+--- a/content/browser/webid/federated_auth_request_impl.cc
++++ b/content/browser/webid/federated_auth_request_impl.cc
+@@ -579,31 +579,6 @@ FederatedAuthRequestImpl::~FederatedAuth
+ void FederatedAuthRequestImpl::Create(
+     RenderFrameHost* host,
+     mojo::PendingReceiver<blink::mojom::FederatedAuthRequest> receiver) {
+-  CHECK(host);
+-
+-  BrowserContext* browser_context = host->GetBrowserContext();
+-  raw_ptr<FederatedIdentityApiPermissionContextDelegate>
+-      api_permission_context =
+-          browser_context->GetFederatedIdentityApiPermissionContext();
+-  raw_ptr<FederatedIdentityAutoReauthnPermissionContextDelegate>
+-      auto_reauthn_permission_context =
+-          browser_context->GetFederatedIdentityAutoReauthnPermissionContext();
+-  raw_ptr<FederatedIdentityPermissionContextDelegate> permission_context =
+-      browser_context->GetFederatedIdentityPermissionContext();
+-  raw_ptr<IdentityRegistry> identity_registry =
+-      IdentityRegistry::FromWebContents(WebContents::FromRenderFrameHost(host));
+-
+-  if (!api_permission_context || !auto_reauthn_permission_context ||
+-      !permission_context) {
+-    return;
+-  }
+-
+-  // FederatedAuthRequestImpl owns itself. It will self-destruct when a mojo
+-  // interface error occurs, the RenderFrameHost is deleted, or the
+-  // RenderFrameHost navigates to a new document.
+-  new FederatedAuthRequestImpl(
+-      *host, api_permission_context, auto_reauthn_permission_context,
+-      permission_context, identity_registry, std::move(receiver));
+ }
+ 
+ FederatedAuthRequestImpl& FederatedAuthRequestImpl::CreateForTesting(

--- a/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
+++ b/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
@@ -810,7 +810,7 @@
  #include "content/public/browser/browser_context.h"
  #include "content/public/browser/browser_thread.h"
  #include "content/public/browser/first_party_sets_handler.h"
-@@ -1167,15 +1166,8 @@ void ProfileNetworkContextService::Confi
+@@ -1154,15 +1153,8 @@ void ProfileNetworkContextService::Confi
  
    network_context_params->enable_certificate_reporting = true;
  

--- a/patches/extra/inox-patchset/0006-modify-default-prefs.patch
+++ b/patches/extra/inox-patchset/0006-modify-default-prefs.patch
@@ -23,7 +23,7 @@
    // used for mapping the command-line flags).
 --- a/chrome/browser/net/profile_network_context_service.cc
 +++ b/chrome/browser/net/profile_network_context_service.cc
-@@ -428,7 +428,7 @@ void ProfileNetworkContextService::Updat
+@@ -415,7 +415,7 @@ void ProfileNetworkContextService::Updat
  void ProfileNetworkContextService::RegisterProfilePrefs(
      user_prefs::PrefRegistrySyncable* registry) {
    registry->RegisterBooleanPref(embedder_support::kAlternateErrorPagesEnabled,

--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -23,6 +23,7 @@
 # the feedback entry in the third party cookie popup
 # unneeded elements from the profile menu
 # the 'Learn more' link on crashed tabs
+# the Third-party sign-in site settings (FedCM)
 # disable LiveCaption flag by default, this also removes non-functional Live Caption checkbox from media controls
 # the new feature badges
 
@@ -447,6 +448,17 @@
  
  void SadTabView::OnBoundsChanged(const gfx::Rect& previous_bounds) {
    // Specify the maximum message and title width explicitly.
+--- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
++++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
+@@ -3238,7 +3238,7 @@ void AddSiteSettingsStrings(content::Web
+       base::FeatureList::IsEnabled(blink::features::kWebPrinting));
+ 
+   html_source->AddBoolean("enableFederatedIdentityApiContentSetting",
+-                          base::FeatureList::IsEnabled(features::kFedCm));
++                          false);
+ 
+   base::CommandLine& cmd = *base::CommandLine::ForCurrentProcess();
+   html_source->AddBoolean(
 --- a/media/base/media_switches.cc
 +++ b/media/base/media_switches.cc
 @@ -938,7 +938,7 @@ BASE_FEATURE(kOnDeviceWebSpeech,


### PR DESCRIPTION
This PR contains two commits with small bugfixes:

* A fix for the safebrowsing patch for mac and win.  The enterprise cert store is not built, so these functions are not available.  
* Disable the creation of the FedCM implementation.  Some users are able to trigger this, so lets ensure it is not able to function.  There's also a change to remove the interface option in the UI removal patch.  Fixes #2869