### PR TITLE
Fix for client certificates

### DIFF
--- a/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
+++ b/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
@@ -576,16 +576,6 @@
    // Returns the profile email if real-time URL check is set for the profile,
    // the device ID if it is set for the device, or an empty string if it is
    // unset.
---- a/chrome/browser/enterprise/connectors/device_trust/key_management/core/network/BUILD.gn
-+++ b/chrome/browser/enterprise/connectors/device_trust/key_management/core/network/BUILD.gn
-@@ -35,7 +35,6 @@ source_set("network") {
-   public_deps = [
-     ":common",
-     "//base",
--    "//components/enterprise/client_certificates/core",
-     "//net",
-     "//url",
-   ]
 --- a/chrome/browser/enterprise/connectors/device_trust/signals/decorators/common/context_signals_decorator.cc
 +++ b/chrome/browser/enterprise/connectors/device_trust/signals/decorators/common/context_signals_decorator.cc
 @@ -26,25 +26,6 @@ enum class PasswordProtectionTrigger {
@@ -1554,30 +1544,6 @@
  
  #if BUILDFLAG(IS_MAC)
    // Do not allow picker UI to be shown on a page that isn't in the foreground
---- a/chrome/browser/net/profile_network_context_service.cc
-+++ b/chrome/browser/net/profile_network_context_service.cc
-@@ -286,20 +286,7 @@ void UpdateCookieSettings(Profile* profi
- std::unique_ptr<net::ClientCertStore> GetWrappedCertStore(
-     Profile* profile,
-     std::unique_ptr<net::ClientCertStore> platform_store) {
--  if (!profile || !client_certificates::features::
--                      IsManagedClientCertificateForUserEnabled()) {
--    return platform_store;
--  }
--
--  auto* provisioning_service =
--      client_certificates::CertificateProvisioningServiceFactory::GetForProfile(
--          profile);
--  if (!provisioning_service) {
--    return platform_store;
--  }
--
--  return client_certificates::ClientCertificatesService::Create(
--      provisioning_service, std::move(platform_store));
-+  return nullptr;
- }
- #endif  // BUILDFLAG(IS_WIN) || BUILDFLAG(IS_MAC)
- 
 --- a/chrome/browser/notifications/notification_display_service_impl.cc
 +++ b/chrome/browser/notifications/notification_display_service_impl.cc
 @@ -88,13 +88,6 @@ NotificationDisplayServiceImpl::Notifica
@@ -2826,7 +2792,7 @@
      "//components/safe_browsing/content/browser/web_ui",
 --- a/components/enterprise/buildflags/buildflags.gni
 +++ b/components/enterprise/buildflags/buildflags.gni
-@@ -12,17 +12,17 @@ declare_args() {
+@@ -12,14 +12,14 @@ declare_args() {
    # Indicates support for content analysis against a cloud agent for Enterprise
    # Connector policies.
    enterprise_cloud_content_analysis =
@@ -2843,11 +2809,7 @@
 +  enterprise_data_controls = false
  
    # Indicates support for client certificates provisioning.
--  enterprise_client_certificates = is_win || is_mac || is_linux
-+  enterprise_client_certificates = false
- 
-   # The watermark is currently implemented using the views framework
-   enterprise_watermark =
+   enterprise_client_certificates = is_win || is_mac || is_linux
 @@ -35,7 +35,7 @@ declare_args() {
    # the fact that `enterprise_cloud_content_analysis` is a superset of
    # `enterprise_local_content_analysis`.

--- a/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
+++ b/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
@@ -810,7 +810,7 @@
  #include "content/public/browser/browser_context.h"
  #include "content/public/browser/browser_thread.h"
  #include "content/public/browser/first_party_sets_handler.h"
-@@ -1154,15 +1153,8 @@ void ProfileNetworkContextService::Confi
+@@ -1167,15 +1166,8 @@ void ProfileNetworkContextService::Confi
  
    network_context_params->enable_certificate_reporting = true;
  

--- a/patches/extra/inox-patchset/0006-modify-default-prefs.patch
+++ b/patches/extra/inox-patchset/0006-modify-default-prefs.patch
@@ -23,7 +23,7 @@
    // used for mapping the command-line flags).
 --- a/chrome/browser/net/profile_network_context_service.cc
 +++ b/chrome/browser/net/profile_network_context_service.cc
-@@ -415,7 +415,7 @@ void ProfileNetworkContextService::Updat
+@@ -428,7 +428,7 @@ void ProfileNetworkContextService::Updat
  void ProfileNetworkContextService::RegisterProfilePrefs(
      user_prefs::PrefRegistrySyncable* registry) {
    registry->RegisterBooleanPref(embedder_support::kAlternateErrorPagesEnabled,


### PR DESCRIPTION
This PR reverts some changes for the client certificate store.  It seems that the changes that required these removals no longer exist or have had their safebrowsing sections gated since they were added.  This should fix https://github.com/ungoogled-software/ungoogled-chromium-windows/issues/351

@Cubik65536 @teeminus let me know if this gives you any trouble building or linking since it also reverts the previous fix.  