### PR TITLE
Various UI and history fixes

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-close-confirmation.patch
@@ -16,11 +16,16 @@
        override_bounds_(params.initial_bounds),
        initial_show_state_(params.initial_show_state),
        initial_workspace_(params.initial_workspace),
-@@ -940,21 +942,23 @@ Browser::WarnBeforeClosingResult Browser
-   if (force_skip_warning_user_on_close_) {
+@@ -941,20 +943,22 @@ Browser::WarnBeforeClosingResult Browser
      return WarnBeforeClosingResult::kOkToClose;
    }
-+
+ 
+-  // `CanCloseWithInProgressDownloads()` may trigger a modal dialog.
+-  bool can_close_with_downloads = CanCloseWithInProgressDownloads();
+-  if (can_close_with_downloads &&
+-      !ShouldShowCookieMigrationNoticeForBrowser(*this)) {
+-    return WarnBeforeClosingResult::kOkToClose;
+-  }
 +  if (CanCloseWithMultipleTabs()) {
 +    // `CanCloseWithInProgressDownloads()` may trigger a modal dialog.
 +    bool can_close_with_downloads = CanCloseWithInProgressDownloads();
@@ -29,13 +34,6 @@
 +      return WarnBeforeClosingResult::kOkToClose;
 +    }
  
--  // `CanCloseWithInProgressDownloads()` may trigger a modal dialog.
--  bool can_close_with_downloads = CanCloseWithInProgressDownloads();
--  if (can_close_with_downloads &&
--      !ShouldShowCookieMigrationNoticeForBrowser(*this)) {
--    return WarnBeforeClosingResult::kOkToClose;
--  }
--
 -  // If there is no download warning, show the cookie migration notice now.
 -  // Otherwise, the download warning is being shown. Cookie migration notice
 -  // will be shown after, if needed.

--- a/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-disable-local-history-expiration.patch
@@ -31,3 +31,12 @@
  }
  
  void HistoryBackend::OnMemoryPressure(
+@@ -1547,6 +1549,8 @@ void HistoryBackend::AddPagesWithDetails
+ }
+ 
+ bool HistoryBackend::IsExpiredVisitTime(const base::Time& time) const {
++  if (base::CommandLine::ForCurrentProcess()->HasSwitch("keep-old-history"))
++    return false;
+   return time < expirer_.GetCurrentExpirationTime();
+ }
+ 

--- a/patches/extra/ungoogled-chromium/disable-formatting-in-omnibox.patch
+++ b/patches/extra/ungoogled-chromium/disable-formatting-in-omnibox.patch
@@ -1,30 +1,22 @@
-# Disables omission of URL elements in Omnibox
-# except for the mailto scheme so that email links can be properly 
-# formatted when copied to clipboard (#2225). 
+# Disables omission of URL elements in Omnibox and status bubble
 
---- a/components/url_formatter/url_formatter.cc
-+++ b/components/url_formatter/url_formatter.cc
-@@ -534,15 +534,15 @@ bool HasTwoViewSourceSchemes(std::string
- }  // namespace
+--- a/chrome/browser/ui/status_bubble.h
++++ b/chrome/browser/ui/status_bubble.h
+@@ -18,7 +18,7 @@ class GURL;
+ class StatusBubble {
+  public:
+   // On hover, expand status bubble to fit long URL after this delay.
+-  static const int kExpandHoverDelayMS = 1600;
++  static const int kExpandHoverDelayMS = 0;
  
- const FormatUrlType kFormatUrlOmitNothing = 0;
--const FormatUrlType kFormatUrlOmitUsernamePassword = 1 << 0;
--const FormatUrlType kFormatUrlOmitHTTP = 1 << 1;
--const FormatUrlType kFormatUrlOmitTrailingSlashOnBareHostname = 1 << 2;
--const FormatUrlType kFormatUrlOmitHTTPS = 1 << 3;
--const FormatUrlType kFormatUrlOmitTrivialSubdomains = 1 << 5;
--const FormatUrlType kFormatUrlTrimAfterHost = 1 << 6;
--const FormatUrlType kFormatUrlOmitFileScheme = 1 << 7;
-+const FormatUrlType kFormatUrlOmitUsernamePassword = 0 << 0;
-+const FormatUrlType kFormatUrlOmitHTTP = 0 << 1;
-+const FormatUrlType kFormatUrlOmitTrailingSlashOnBareHostname = 0 << 2;
-+const FormatUrlType kFormatUrlOmitHTTPS = 0 << 3;
-+const FormatUrlType kFormatUrlOmitTrivialSubdomains = 0 << 5;
-+const FormatUrlType kFormatUrlTrimAfterHost = 0 << 6;
-+const FormatUrlType kFormatUrlOmitFileScheme = 0 << 7;
- const FormatUrlType kFormatUrlOmitMailToScheme = 1 << 8;
--const FormatUrlType kFormatUrlOmitMobilePrefix = 1 << 9;
-+const FormatUrlType kFormatUrlOmitMobilePrefix = 0 << 9;
+   virtual ~StatusBubble() {}
  
- const FormatUrlType kFormatUrlOmitDefaults =
-     kFormatUrlOmitUsernamePassword | kFormatUrlOmitHTTP |
+--- a/chrome/browser/ui/toolbar/chrome_location_bar_model_delegate.cc
++++ b/chrome/browser/ui/toolbar/chrome_location_bar_model_delegate.cc
+@@ -261,5 +261,5 @@ TemplateURLService* ChromeLocationBarMod
+ // static
+ void ChromeLocationBarModelDelegate::RegisterProfilePrefs(
+     user_prefs::PrefRegistrySyncable* registry) {
+-  registry->RegisterBooleanPref(omnibox::kPreventUrlElisionsInOmnibox, false);
++  registry->RegisterBooleanPref(omnibox::kPreventUrlElisionsInOmnibox, true);
+ }

--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -20,6 +20,7 @@
 # the 'Learn more' link from the search engine entry on the settings page
 # Safety Check entry on the side menu on the settings page
 # the (?) learn more button on many settings pages
+# 'Sign in to see tabs from other devices' in the history submenu
 # the 'Vist Chrome Web Store' entry in the extensions section of the main menu
 # the side panel entry in All Bookmarks
 # the feedback entry in the third party cookie popup
@@ -363,6 +364,16 @@
          <cr-icon-button iron-icon="cr:help-outline" dir="ltr"
              aria-label="[[getLearnMoreAriaLabel_(pageTitle)]]"
              aria-description="$i18n{opensInNewTab}" on-click="onHelpClick_">
+--- a/chrome/browser/ui/tabs/recent_tabs_sub_menu_model.cc
++++ b/chrome/browser/ui/tabs/recent_tabs_sub_menu_model.cc
+@@ -347,7 +347,6 @@ void RecentTabsSubMenuModel::Build() {
+   AddSeparator(ui::NORMAL_SEPARATOR);
+   history_separator_index_ = GetItemCount() - 1;
+   BuildLocalEntries();
+-  BuildTabsFromOtherDevices();
+ }
+ 
+ void RecentTabsSubMenuModel::BuildLocalEntries() {
 --- a/chrome/browser/ui/toolbar/app_menu_model.cc
 +++ b/chrome/browser/ui/toolbar/app_menu_model.cc
 @@ -857,16 +857,6 @@ void ExtensionsMenuModel::Build(Browser*

--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -5,6 +5,8 @@
 # the 'Learn more' link on new incognito tabs
 # Live captions entry from the settings page
 # link to Google's accessibility site from the settings page
+# update status icon on the About page
+# update status text on the About page
 # link to Google's help site on the About page
 # external link for theme entry on settings page
 # webstore text for theme entry on settings page
@@ -152,6 +154,24 @@
        <template is="dom-if" if="[[!captionSettingsOpensExternally_]]">
 --- a/chrome/browser/resources/settings/about_page/about_page.html
 +++ b/chrome/browser/resources/settings/about_page/about_page.html
+@@ -52,7 +52,7 @@
+       <div class="cr-row two-line">
+         <!-- Set the icon from the iconset (when it's obsolete/EOL and
+           when update is done) or set the src (when it's updating). -->
+-<if expr="not chromeos_ash">
++<if expr="False">
+         <div class="icon-container"
+             hidden="[[!shouldShowIcons_(showUpdateStatus_)]]">
+           <iron-icon
+@@ -64,7 +64,7 @@
+         </div>
+ </if>
+         <div class="flex cr-padded-text">
+-<if expr="not chromeos_ash">
++<if expr="False">
+           <div id="updateStatusMessage" hidden="[[!showUpdateStatus_]]">
+             <div role="alert" aria-live="polite"
+                 inner-h-t-m-l="[[getUpdateStatusMessage_(
 @@ -120,11 +120,6 @@
          </div>
        </template>


### PR DESCRIPTION
This PR contains a series of commits that address some existing issues:  
* The status info on the about page is removed.  This seems to have only manifested as an issue on mac but the underlying problem was mostly platform agnostic.  
  Fixes https://github.com/ungoogled-software/ungoogled-chromium-macos/issues/145
* The history submenu in the main menu had an entry that requires sign-in and has been removed.  
* Importing history with the keep-old-history flag enabled should now import all history.  
  Fixes #2899 
* The URL formatting patch has been overhauled to allow the omnibox toggle to function correctly and show only the domain info in the site info popup.  Showing the full URL info is still the default and can be changed by right-clicking the addressbar and toggling the "Always show full URLs" option.  I've also added a change to always show the full URL info in the status bubble.  
  Fixes #1051 #2779 #2721

This is also the first time the new changes in the close confirmation patch are being refreshed by quilt, no functional changes have been made.  