### PR TITLE
Disable DownloadsPageReferrerUrl feature by default

### DIFF
--- a/patches/extra/ungoogled-chromium/disable-downloads-page-referrer-url.patch
+++ b/patches/extra/ungoogled-chromium/disable-downloads-page-referrer-url.patch
@@ -1,0 +1,11 @@
+--- a/components/safe_browsing/core/common/features.cc
++++ b/components/safe_browsing/core/common/features.cc
+@@ -205,7 +205,7 @@ BASE_FEATURE(kHashPrefixRealTimeLookupsFasterOhttpKeyRotation,
+ 
+ BASE_FEATURE(kDownloadsPageReferrerUrl,
+              "DownloadsPageReferrerUrl",
+-             base::FEATURE_ENABLED_BY_DEFAULT);
++             base::FEATURE_DISABLED_BY_DEFAULT);
+ 
+ BASE_FEATURE(kLogAccountEnhancedProtectionStateInProtegoPings,
+              "TailoredSecurityLogAccountEnhancedProtectionStateInProtegoPings",

--- a/patches/series
+++ b/patches/series
@@ -104,3 +104,4 @@ extra/ungoogled-chromium/first-run-page.patch
 extra/ungoogled-chromium/disable-capture-all-screens.patch
 extra/ungoogled-chromium/add-flag-to-reduce-system-info.patch
 extra/ungoogled-chromium/add-flag-to-remove-client-hints.patch
+extra/ungoogled-chromium/disable-downloads-page-referrer-url.patch


### PR DESCRIPTION
Disable DownloadsPageReferrerUrl feature by default

This patch will disable `DownloadsPageReferrerUrl` feature by default.

The `DownloadsPageReferrerUrl` feature is introduced by https://chromium-review.googlesource.com/c/chromium/src/+/5589888 .

> [Downloads] Show referrer url on chrome://downloads items
> 
> This swaps the existing download url on a download item with the referrer url. Clicking the
> link will open the download's referrer/origin in a new tab. It's wrapped behind a feature flag.

Since chromium 127, users are unable to get real download url from `chrome://downloads`.

For example, download this file using chromium: https://commondatastorage.googleapis.com/chromium-browser-official/chromium-128.0.6613.84.tar.xz

The `chrome://downloads` page only shows its referrer. Click "Copy Link Address" in the menu will get its referrer `https://github.com/...` instead of real download url `https://commondatastorage.googleapis.com/...`.

<img width="732" alt="1" src="https://github.com/user-attachments/assets/677d43b0-3fcc-401e-a8d0-1794ac06e9f3">

If we copy this link and paste to omnibox to download (without referrer), the url part will be completely empty.

<img width="731" alt="2" src="https://github.com/user-attachments/assets/506f84a9-0924-407c-9a42-033a968c368c">

I don't think it is a meaningful feature. It makes user more difficult to get the real url (especially the download link has redirects). Also, the original url will be lost if we download mannually by url. Disable it so chromium's `chrome://downloads` will behave the same as before version 127.

<img width="717" alt="3" src="https://github.com/user-attachments/assets/5df89005-0e96-49ec-834d-0430a7b134d2">
