### PR TITLE
Enable blocking all downloads via managed policy

### DIFF
--- a/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
+++ b/patches/core/ungoogled-chromium/fix-building-without-safebrowsing.patch
@@ -250,7 +250,7 @@
    }
    if (ShouldBlockFile(item, target_info.danger_type)) {
      MaybeReportDangerousDownloadBlocked(
-@@ -1767,53 +1756,6 @@ bool ChromeDownloadManagerDelegate::IsOp
+@@ -1767,49 +1756,20 @@ bool ChromeDownloadManagerDelegate::IsOp
  bool ChromeDownloadManagerDelegate::ShouldBlockFile(
      download::DownloadItem* item,
      download::DownloadDangerType danger_type) const {
@@ -259,9 +259,9 @@
 -    return false;
 -  }
 -
--  DownloadPrefs::DownloadRestriction download_restriction =
--      download_prefs_->download_restriction();
--
+   DownloadPrefs::DownloadRestriction download_restriction =
+       download_prefs_->download_restriction();
+ 
 -  if (IsDangerTypeBlocked(danger_type))
 -    return true;
 -
@@ -269,10 +269,10 @@
 -      (item && DownloadItemModel(item).GetDangerLevel() !=
 -                   DownloadFileType::NOT_DANGEROUS);
 -
--  switch (download_restriction) {
--    case (DownloadPrefs::DownloadRestriction::NONE):
--      return false;
--
+   switch (download_restriction) {
+     case (DownloadPrefs::DownloadRestriction::NONE):
+       return false;
+ 
 -    case (DownloadPrefs::DownloadRestriction::POTENTIALLY_DANGEROUS_FILES):
 -      return danger_type != download::DOWNLOAD_DANGER_TYPE_NOT_DANGEROUS ||
 -             file_type_dangerous;
@@ -294,17 +294,17 @@
 -                  download::DOWNLOAD_DANGER_TYPE_DANGEROUS_ACCOUNT_COMPROMISE);
 -    }
 -
--    case (DownloadPrefs::DownloadRestriction::ALL_FILES):
--      return true;
--
--    default:
--      LOG(ERROR) << "Invalid download restriction value: "
--                 << static_cast<int>(download_restriction);
--  }
+     case (DownloadPrefs::DownloadRestriction::ALL_FILES):
+       return true;
  
-   return false;
- }
-@@ -1828,7 +1770,6 @@ void ChromeDownloadManagerDelegate::Mayb
++    // DownloadRestrictions policy key values 1, 2 and 4 treated as invalid
++    case (DownloadPrefs::DownloadRestriction::POTENTIALLY_DANGEROUS_FILES):
++    case (DownloadPrefs::DownloadRestriction::DANGEROUS_FILES):
++    case (DownloadPrefs::DownloadRestriction::MALICIOUS_FILES):
+     default:
+       LOG(ERROR) << "Invalid download restriction value: "
+                  << static_cast<int>(download_restriction);
+@@ -1828,7 +1788,6 @@
      service->MaybeSendDangerousDownloadOpenedReport(download,
                                                      show_download_in_folder);
    }
@@ -312,7 +312,7 @@
    if (!download->GetAutoOpened()) {
      download::DownloadContent download_content =
          download::DownloadContentFromMimeType(download->GetMimeType(), false);
-@@ -1836,6 +1777,7 @@ void ChromeDownloadManagerDelegate::Mayb
+@@ -1836,6 +1795,7 @@ void ChromeDownloadManagerDelegate::Mayb
          download->GetDangerType(), download_content, base::Time::Now(),
          download->GetEndTime(), show_download_in_folder);
    }
@@ -320,7 +320,7 @@
  }
  
  void ChromeDownloadManagerDelegate::MaybeSendDangerousDownloadCanceledReport(
-@@ -1960,8 +1902,7 @@ void ChromeDownloadManagerDelegate::Chec
+@@ -1960,8 +1920,7 @@ void ChromeDownloadManagerDelegate::Chec
    DCHECK(download_item);
    DCHECK(download_item->IsSavePackageDownload());
  


### PR DESCRIPTION
In a nutshell, this commit allows users to set the DownloadRestrictions managed policy key to either 0 or 3 to respectively permit or block all downloads.

The [key values](https://chromeenterprise.google/policies/#DownloadRestrictions) are as follows.....

0 = No special restrictions. Default.
1 = Block malicious downloads and dangerous file types.
2 = Block malicious downloads, uncommon or unwanted downloads and dangerous file types.
3 = Block all downloads.
4 = Block malicious downloads. Recommended.

In this commit, DownloadRestrictions values of 1, 2 and 4 are effectively neutered by disentangling them from safebrowsing and treating them as invalid. None of the reinstated code appears to be connected to safebrowsing.

The relevant section of chrome/browser/download/chrome_download_manager_delegate.cc will end up looking like this.....

```
bool ChromeDownloadManagerDelegate::ShouldBlockFile(
    download::DownloadItem* item,
    download::DownloadDangerType danger_type) const {
  DownloadPrefs::DownloadRestriction download_restriction =
      download_prefs_->download_restriction();

  switch (download_restriction) {
    case (DownloadPrefs::DownloadRestriction::NONE):
      return false;

    case (DownloadPrefs::DownloadRestriction::ALL_FILES):
      return true;

    // DownloadRestrictions policy key values 1, 2 and 4 treated as invalid
    case (DownloadPrefs::DownloadRestriction::POTENTIALLY_DANGEROUS_FILES):
    case (DownloadPrefs::DownloadRestriction::DANGEROUS_FILES):
    case (DownloadPrefs::DownloadRestriction::MALICIOUS_FILES):
    default:
      LOG(ERROR) << "Invalid download restriction value: "
                 << static_cast<int>(download_restriction);
  }

  return false;
}
```

I have tested DownloadRestrictions values of 0-5, with 0 and 3 behaving as expected. Running without a policy file also behaves as expected, same as 0 (ie there is no intrinsic change in behaviour from this commit).

Values 1, 2 and 4 behave the same as 5, emitting a non-fatal "Invalid download restriction value" error and allowing the download to proceed. 

This PR will fix issue #2974.