### PR TITLE
Fix builds with DCHECK enabled

### DIFF
--- a/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
+++ b/patches/core/ungoogled-chromium/remove-unused-preferences-fields.patch
@@ -6558,7 +6558,20 @@
      } else if (ShouldSigninAllowedPrefAffectPrimaryAccount(
                     pref_consented_to_sync)) {
        SetPrimaryAccountInternal(CoreAccountInfo(), /*consented_to_sync=*/false,
-@@ -545,10 +417,6 @@ void PrimaryAccountManager::SetSyncPrima
+@@ -527,10 +399,9 @@ void PrimaryAccountManager::SetSyncPrima
+ 
+ #if DCHECK_IS_ON()
+   {
+-    std::string pref_account_id =
+-        client_->GetPrefs()->GetString(prefs::kGoogleServicesAccountId);
++    std::string pref_account_id;
+     bool consented_to_sync =
+-        client_->GetPrefs()->GetBoolean(prefs::kGoogleServicesConsentedToSync);
++        false;
+ 
+     DCHECK(pref_account_id.empty() || !consented_to_sync ||
+            pref_account_id == account_info.account_id.ToString())
+@@ -545,10 +416,6 @@ void PrimaryAccountManager::SetSyncPrima
    // Go ahead and update the last signed in account info here as well. Once a
    // user is signed in the corresponding preferences should match. Doing it here
    // as opposed to on signin allows us to catch the upgrade scenario.
@@ -6569,7 +6582,7 @@
  }
  
  void PrimaryAccountManager::SetPrimaryAccountInternal(
-@@ -560,22 +428,6 @@ void PrimaryAccountManager::SetPrimaryAc
+@@ -560,22 +427,6 @@ void PrimaryAccountManager::SetPrimaryAc
    // 'account_info' might be a reference to the contents of `primary_account_`.
    // Create a PrimaryAccount object before calling emplace to avoid crashes.
    primary_account_.emplace(PrimaryAccount(account_info, consented_to_sync));
@@ -6592,7 +6605,7 @@
  }
  
  void PrimaryAccountManager::RecordHadPreviousSyncAccount() const {
-@@ -585,7 +437,7 @@ void PrimaryAccountManager::RecordHadPre
+@@ -585,7 +436,7 @@ void PrimaryAccountManager::RecordHadPre
    }
  
    const std::string& last_gaia_id_with_sync_enabled =
@@ -6601,7 +6614,7 @@
    const bool existed_primary_account_with_sync =
        !last_gaia_id_with_sync_enabled.empty();
  
-@@ -735,38 +587,6 @@ PrimaryAccountChangeEvent::State Primary
+@@ -735,38 +586,6 @@ PrimaryAccountChangeEvent::State Primary
  void PrimaryAccountManager::ComputeExplicitBrowserSignin(
      const PrimaryAccountChangeEvent& event_details,
      ScopedPrefCommit& scoped_pref_commit) {
@@ -6640,7 +6653,7 @@
  }
  
  void PrimaryAccountManager::FirePrimaryAccountChanged(
-@@ -850,7 +670,6 @@ void PrimaryAccountManager::OnSigninAllo
+@@ -850,7 +669,6 @@ void PrimaryAccountManager::OnSigninAllo
  bool PrimaryAccountManager::ShouldSigninAllowedPrefAffectPrimaryAccount(
      bool is_sync_consent) {
    return switches::IsExplicitBrowserSigninUIOnDesktopEnabled() &&


### PR DESCRIPTION
Removes stranded uses of preferences members patched out elsewhere. As the only occurrences appear to be in portions compiled only when DCHECK is enabled, this allows full debug builds to now succeed. Fixes #3008.
