### PR TITLE
Fix empty i18nId in settings

### DIFF
--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -204,15 +204,23 @@
              <div class="separator"></div>
 --- a/chrome/browser/resources/settings/appearance_page/appearance_page.ts
 +++ b/chrome/browser/resources/settings/appearance_page/appearance_page.ts
-@@ -527,7 +527,7 @@ export class SettingsAppearancePageEleme
-       this.themeSublabel_ = '';
-       return;
+@@ -521,15 +521,11 @@ export class SettingsAppearancePageEleme
+         i18nId = 'classicTheme';
+         break;
      }
--    i18nId = 'chooseFromWebStore';
-+    i18nId = '';
++    this.themeSublabel_ = this.i18n(i18nId);
      // </if>
-     this.themeSublabel_ = this.i18n(i18nId);
+     // <if expr="not is_linux">
+-    if (this.toolbarPinningEnabled_) {
+       this.themeSublabel_ = '';
+-      return;
+-    }
+-    i18nId = 'chooseFromWebStore';
+     // </if>
+-    this.themeSublabel_ = this.i18n(i18nId);
    }
+ 
+   /** @return Whether applied theme is set by policy. */
 --- a/chrome/browser/resources/settings/autofill_page/payments_section.html
 +++ b/chrome/browser/resources/settings/autofill_page/payments_section.html
 @@ -80,11 +80,6 @@


### PR DESCRIPTION
This PR resolves an issue where an empty internationalization ID causes settings pages to fail on non-linux builds.  
Fixes #3011 