### PR TITLE
Add missing re2 deps

### DIFF
--- a/patches/upstream-fixes/missing-dependencies.patch
+++ b/patches/upstream-fixes/missing-dependencies.patch
@@ -38,6 +38,26 @@
      "//device/vr/buildflags",
    ]
  }
+--- a/components/component_updater/installer_policies/BUILD.gn
++++ b/components/component_updater/installer_policies/BUILD.gn
+@@ -45,6 +45,7 @@ static_library("installer_policies_no_co
+     "//components/update_client",
+     "//mojo/public/cpp/base:protobuf_support",
+     "//services/network/public/cpp",
++    "//third_party/re2",
+   ]
+ 
+   # Disallow depending on content.
+--- a/components/plus_addresses/BUILD.gn
++++ b/components/plus_addresses/BUILD.gn
+@@ -95,6 +95,7 @@ source_set("plus_addresses") {
+     "//net",
+     "//services/data_decoder/public/cpp",
+     "//services/network/public/cpp",
++    "//third_party/re2",
+     "//ui/base",
+   ]
+   public_deps = [
 --- a/content/browser/BUILD.gn
 +++ b/content/browser/BUILD.gn
 @@ -91,6 +91,7 @@ source_set("browser") {


### PR DESCRIPTION
The u-c build fails in a couple of places due to missing re2 dependencies, that the upstream build supplies via a component that we remove ([per @Ahrotahn](https://github.com/ungoogled-software/ungoogled-chromium/pull/3029#issuecomment-2366806315)):
```
FAILED: obj/components/plus_addresses/plus_addresses/plus_address_service.o
[...]
In file included from ../../components/plus_addresses/plus_address_service.cc:31:
In file included from ../../components/plus_addresses/plus_address_blocklist_data.h:11:
../../third_party/re2/src/re2/re2.h:223:10: fatal error: 're2/stringpiece.h' file not found
#include "re2/stringpiece.h"
         ^~~~~~~~~~~~~~~~~~~

FAILED: obj/components/component_updater/installer_policies/installer_policies_no_content_deps/plus_address_blocklist_component_installer.o
[...]
In file included from ../../components/component_updater/installer_policies/plus_address_blocklist_component_installer.cc:18:
In file included from ../../components/plus_addresses/plus_address_blocklist_data.h:11:
../../third_party/re2/src/re2/re2.h:223:10: fatal error: 're2/stringpiece.h' file not found
#include "re2/stringpiece.h"
         ^~~~~~~~~~~~~~~~~~~
```

(This build failure was first reported [here](https://github.com/ungoogled-software/ungoogled-chromium/pull/3029#issuecomment-2365216275).)

This PR adds the re2 deps to `missing-dependencies.patch`, as advised.