### PR TITLE
CI: fix version check workflow by url encoding filter in url

### DIFF
--- a/.github/workflows/new_version_check.yml
+++ b/.github/workflows/new_version_check.yml
@@ -25,7 +25,7 @@ jobs:
         run: |
           set -eo pipefail
           BASE_URL="https://versionhistory.googleapis.com/v1/chrome/platforms"
-          END_URL="channels/stable/versions/all/releases?filter=endtime=none,fraction>=0.5&order_by=version%20desc"
+          END_URL="channels/stable/versions/all/releases?filter=endtime%3Dnone%2Cfraction%3E%3D0.5&order_by=version%20desc"
           JQ_FILTER='if .releases | select(type=="array") | length > 0 then .releases | first | .version else "null" end'
           for platform in linux win mac; do
             printf %s "${platform}_version=" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This workflow stated consistently failing roughly one week ago. Unfortunately the Workflow on GitHub has no error logs besides

~~~
Error: Process completed with exit code 92.
~~~

which isn't particularly helpful.

The issue can, however, be reproduced by simply copying parts of the workflow into a local bash script and executing that.

As it turns out, the issue lays in `?filter=fraction>=0.5` when using `curl` due to missing url encoding.

~~~bash
# curl 'https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases?filter=fraction>=0.5'
curl: (92) HTTP/2 stream 1 was not closed cleanly: PROTOCOL_ERROR (err 1)
~~~

vs

~~~bash
# curl -s 'https://versionhistory.googleapis.com/v1/chrome/platforms/linux/channels/stable/versions/all/releases?filter=fraction%3E=0.5' | wc -l
3128
~~~
