### PR TITLE
when pruning files log missing file paths together with the error message

### DIFF
--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -128,9 +128,9 @@ def _callback(args):
     prune_list = tuple(filter(len, args.pruning_list.read_text(encoding=ENCODING).splitlines()))
     unremovable_files = prune_files(args.directory, prune_list)
     if unremovable_files:
-        file_list='n'.join(f for f in itertools.islice(unremovable_files, 5))
+        file_list = 'n'.join(f for f in itertools.islice(unremovable_files, 5))
         if len(unremovable_files) > 5:
-            file_list+='\n... and ' + (len(unremovable_files) - 5) + ' more'
+            file_list += '\n... and ' + str(len(unremovable_files) - 5) + ' more'
         get_logger().error('%d files could not be pruned:\n%s', len(unremovable_files), file_list)
         sys.exit(1)
 

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -129,7 +129,7 @@ def _callback(args):
     unremovable_files = prune_files(args.directory, prune_list)
     if unremovable_files:
         get_logger().error('%d files could not be pruned:\n%s', len(unremovable_files), 
-        '\n'.join(f for f in unremovable_files))
+                           '\n'.join(f for f in unremovable_files))
         sys.exit(1)
 
 

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -128,9 +128,7 @@ def _callback(args):
     prune_list = tuple(filter(len, args.pruning_list.read_text(encoding=ENCODING).splitlines()))
     unremovable_files = prune_files(args.directory, prune_list)
     if unremovable_files:
-        get_logger().error('%d files could not be pruned.', len(unremovable_files))
-        get_logger().debug('Files could not be pruned:\n%s',
-                           '\n'.join(f for f in unremovable_files))
+        get_logger().error('%d files could not be pruned:\n%s', len(unremovable_files), '\n'.join(f for f in unremovable_files))
         sys.exit(1)
 
 

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -129,7 +129,7 @@ def _callback(args):
     prune_list = tuple(filter(len, args.pruning_list.read_text(encoding=ENCODING).splitlines()))
     unremovable_files = prune_files(args.directory, prune_list)
     if unremovable_files:
-        file_list = 'n'.join(f for f in itertools.islice(unremovable_files, 5))
+        file_list = '\n'.join(f for f in itertools.islice(unremovable_files, 5))
         if len(unremovable_files) > 5:
             file_list += '\n... and ' + str(len(unremovable_files) - 5) + ' more'
             get_logger().debug('files that could not be pruned:\n%s',

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -128,7 +128,8 @@ def _callback(args):
     prune_list = tuple(filter(len, args.pruning_list.read_text(encoding=ENCODING).splitlines()))
     unremovable_files = prune_files(args.directory, prune_list)
     if unremovable_files:
-        get_logger().error('%d files could not be pruned:\n%s', len(unremovable_files), '\n'.join(f for f in unremovable_files))
+        get_logger().error('%d files could not be pruned:\n%s', len(unremovable_files), 
+        '\n'.join(f for f in unremovable_files))
         sys.exit(1)
 
 

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -132,6 +132,8 @@ def _callback(args):
         file_list = 'n'.join(f for f in itertools.islice(unremovable_files, 5))
         if len(unremovable_files) > 5:
             file_list += '\n... and ' + str(len(unremovable_files) - 5) + ' more'
+            get_logger().debug('files that could not be pruned:\n%s',
+                               '\n'.join(f for f in unremovable_files))
         get_logger().error('%d files could not be pruned:\n%s', len(unremovable_files), file_list)
         sys.exit(1)
 

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -128,8 +128,10 @@ def _callback(args):
     prune_list = tuple(filter(len, args.pruning_list.read_text(encoding=ENCODING).splitlines()))
     unremovable_files = prune_files(args.directory, prune_list)
     if unremovable_files:
-        get_logger().error('%d files could not be pruned:\n%s', len(unremovable_files), 
-                           '\n'.join(f for f in unremovable_files))
+        file_list='n'.join(f for f in itertools.islice(unremovable_files, 5))
+        if len(unremovable_files) > 5:
+            file_list+='\n... and ' + (len(unremovable_files) - 5) + ' more'
+        get_logger().error('%d files could not be pruned:\n%s', len(unremovable_files), file_list)
         sys.exit(1)
 
 

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -7,6 +7,7 @@
 """Prune binaries from the source tree"""
 
 import argparse
+import itertools
 import sys
 import os
 import stat


### PR DESCRIPTION
in case of missing files to prune the prune_binary.py should log their paths together with the error message to ease fixing this. Until now these paths were only logged when debug level is enabled.