### PR TITLE
Manually set up gsutil path for newer versions of Python

### DIFF
--- a/utils/depot_tools.patch
+++ b/utils/depot_tools.patch
@@ -67,7 +67,7 @@
  
 --- a/gclient_scm.py
 +++ b/gclient_scm.py
-@@ -925,8 +925,7 @@ class GitWrapper(SCMWrapper):
+@@ -952,8 +952,7 @@ class GitWrapper(SCMWrapper):
          self._SetFetchConfig(options)
  
          # Fetch upstream if we don't already have |revision|.
@@ -77,7 +77,7 @@
              self._Fetch(options, prune=options.force)
  
              if not scm.GIT.IsValidRevision(
-@@ -942,7 +941,7 @@ class GitWrapper(SCMWrapper):
+@@ -969,7 +968,7 @@ class GitWrapper(SCMWrapper):
  
          # This is a big hammer, debatable if it should even be here...
          if options.force or options.reset:
@@ -86,7 +86,7 @@
              if options.upstream and upstream_branch:
                  target = upstream_branch
              self._Scrub(target, options)
-@@ -957,7 +956,6 @@ class GitWrapper(SCMWrapper):
+@@ -984,7 +983,6 @@ class GitWrapper(SCMWrapper):
              # to the checkout step.
              if not (options.force or options.reset):
                  self._CheckClean(revision)
@@ -94,7 +94,7 @@
  
              if not current_revision:
                  current_revision = self._Capture(
-@@ -1637,8 +1635,7 @@ class GitWrapper(SCMWrapper):
+@@ -1668,8 +1666,7 @@ class GitWrapper(SCMWrapper):
              fetch_cmd.append('--no-tags')
          elif quiet:
              fetch_cmd.append('--quiet')
@@ -111,7 +111,7 @@
  IS_WINDOWS = os.name == 'nt'
  
 -VERSION = '4.68'
-+VERSION = '5.28'
++VERSION = 'GSUVER'
  
  # Google OAuth Context required by gsutil.
  LUCI_AUTH_SCOPES = [


### PR DESCRIPTION
This PR adds a new section to the clone script that manually sets up the gsutil directory with a newer version of apitools so Python 3.13+ can be used.  

Normally gsutil creates this path during runtime and makes an `install.flag` file to signify completion so it only needs to do the work once.  This change writes to the same file in order to prevent gsutil from overwriting our changes.  