### PR TITLE
Move assert_no_deps fix to missing-dependencies.patch

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
+++ b/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
@@ -162,35 +162,6 @@
      "//chrome/test/chromedriver/constants:version_header",
      "//components/crx_file",
      "//components/embedder_support",
---- a/components/BUILD.gn
-+++ b/components/BUILD.gn
-@@ -71,7 +71,7 @@ if (is_ios) {
- 
- # Omit Lacros because it allows //components to depend on //chrome, which in
- # turn depends on //extensions.
--if (!is_chromeos_lacros) {
-+if (false) {
-   disallowed_extension_deps_ = [
-     # Components should largely not depend on //extensions. Since // extensions
-     # is not a component target and is linked with //chrome, depending on most
-@@ -877,7 +877,7 @@ test("components_unittests") {
-   # On other platforms, no components should depend on Chrome.
-   # Since //chrome depends on //extensions, we also only assert_no_deps on
-   # extensions targets for non-lacros builds.
--  if (!is_chromeos_lacros) {
-+  if (false) {
-     assert_no_deps = [ "//chrome/*" ]
-     assert_no_deps += disallowed_extension_deps_
-   }
-@@ -1170,7 +1170,7 @@ if (use_blink) {
-     # dependency. On other platforms, no components should depend on Chrome.
-     # Since //chrome depends on //extensions, we also only assert_no_deps on
-     # extensions targets for non-lacros builds.
--    if (!is_chromeos_lacros) {
-+    if (false) {
-       assert_no_deps = [ "//chrome/*" ]
-       assert_no_deps += disallowed_extension_deps_
-     }
 --- a/content/browser/renderer_host/navigation_request.cc
 +++ b/content/browser/renderer_host/navigation_request.cc
 @@ -42,6 +42,7 @@

--- a/patches/upstream-fixes/missing-dependencies.patch
+++ b/patches/upstream-fixes/missing-dependencies.patch
@@ -86,6 +86,35 @@
      "//components/link_header_util",
      "//components/metrics",
      "//components/metrics:single_sample_metrics",
+--- a/components/BUILD.gn
++++ b/components/BUILD.gn
+@@ -71,7 +71,7 @@ if (is_ios) {
+ 
+ # Omit Lacros because it allows //components to depend on //chrome, which in
+ # turn depends on //extensions.
+-if (!is_chromeos_lacros) {
++if (false) {
+   disallowed_extension_deps_ = [
+     # Components should largely not depend on //extensions. Since // extensions
+     # is not a component target and is linked with //chrome, depending on most
+@@ -877,7 +877,7 @@ test("components_unittests") {
+   # On other platforms, no components should depend on Chrome.
+   # Since //chrome depends on //extensions, we also only assert_no_deps on
+   # extensions targets for non-lacros builds.
+-  if (!is_chromeos_lacros) {
++  if (false) {
+     assert_no_deps = [ "//chrome/*" ]
+     assert_no_deps += disallowed_extension_deps_
+   }
+@@ -1170,7 +1170,7 @@ if (use_blink) {
+     # dependency. On other platforms, no components should depend on Chrome.
+     # Since //chrome depends on //extensions, we also only assert_no_deps on
+     # extensions targets for non-lacros builds.
+-    if (!is_chromeos_lacros) {
++    if (false) {
+       assert_no_deps = [ "//chrome/*" ]
+       assert_no_deps += disallowed_extension_deps_
+     }
 --- a/pdf/pdfium/pdfium_engine_exports.h
 +++ b/pdf/pdfium/pdfium_engine_exports.h
 @@ -15,6 +15,7 @@


### PR DESCRIPTION
missing-dependencies.patch contains a patch that adds `//chrome/common:buildflags` to `deps`:
https://github.com/ungoogled-software/ungoogled-chromium/blob/89fe8ac0edf91ab1a9679f681f106acd815c13f5/patches/upstream-fixes/missing-dependencies.patch#L77
However, this causes an error while building:
```
ERROR at //build/config/BUILDCONFIG.gn:581:5: assert_no_deps failed.
    target(_target_type, _target_name) {
    ^-----------------------------------
//components:components_browsertests has an assert_no_deps entry:
  //chrome/*
which fails for the dependency path:
  //components:components_browsertests ->
  //components/autofill/content/browser:browser ->
  //components/keyed_service/content:content ->
  //content/public/browser:browser ->
  //content/public/browser:browser_sources ->
  //content/browser:browser ->
  //chrome/common:buildflags
```
The fix for this is in another, seemingly unrelated patch:
https://github.com/ungoogled-software/ungoogled-chromium/blob/89fe8ac0edf91ab1a9679f681f106acd815c13f5/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch#L165-L193

Everything works out if you apply all patches, but if you're selectively applying patches it breaks the build. This PR moves the fix from `add-flags-for-referrer-customization.patch` to `missing-dependencies.patch`, which should address the aforementioned concern. The fix is also needed for `add-flags-for-referrer-customization.patch`, but presumably `missing-dependencies.patch` is mandatory so there's less of a chance that it's missed by someone selectively choosing which patches to apply.