### PR TITLE
Remove client hints from frame fetch when flag is enabled

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-to-remove-client-hints.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-remove-client-hints.patch
@@ -68,3 +68,22 @@
  
    UserAgentMetadata metadata = GetUserAgentMetadata();
    ua_data->SetBrandVersionList(metadata.brand_version_list);
+--- a/third_party/blink/renderer/core/loader/frame_fetch_context.cc
++++ b/third_party/blink/renderer/core/loader/frame_fetch_context.cc
+@@ -48,6 +48,7 @@
+ #include "third_party/blink/public/common/associated_interfaces/associated_interface_provider.h"
+ #include "third_party/blink/public/common/client_hints/client_hints.h"
+ #include "third_party/blink/public/common/device_memory/approximated_device_memory.h"
++#include "third_party/blink/public/common/features.h"
+ #include "third_party/blink/public/mojom/fetch/fetch_api_request.mojom-blink.h"
+ #include "third_party/blink/public/mojom/loader/request_context_frame_type.mojom-blink.h"
+ #include "third_party/blink/public/mojom/permissions_policy/permissions_policy.mojom-blink.h"
+@@ -509,6 +510,8 @@ void FrameFetchContext::ModifyRequestFor
+ void FrameFetchContext::AddClientHintsIfNecessary(
+     const std::optional<float> resource_width,
+     ResourceRequest& request) {
++  if (base::FeatureList::IsEnabled(blink::features::kRemoveClientHints))
++    return;
+   if (GetResourceFetcherProperties().IsDetached()) {
+     return;
+   }


### PR DESCRIPTION
This PR updates the client hints patch to account for a separate section that was missed for fetches.  
Fixes #3105

![Screenshot1](https://github.com/user-attachments/assets/91fa4bc4-02b1-4035-a46b-635e3ac69501)
