### PR TITLE
README: Remove mention of OBS for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Other platforms are discussed and tracked in this repository's Issue Tracker. Le
 
 ungoogled-chromium is available in the following **software repositories**:
 
-* Arch: Available in AUR & OBS, [see instructions in ungoogled-chromium-archlinux](https://github.com/ungoogled-software/ungoogled-chromium-archlinux)
+* Arch: Available in the AUR, [see instructions in ungoogled-chromium-archlinux](https://github.com/ungoogled-software/ungoogled-chromium-archlinux)
 * Debian & Ubuntu: Available in OBS, find your [distribution specific instructions](https://github.com/ungoogled-software/ungoogled-chromium-debian) in the Installing section
 * Fedora: Available in [COPR](https://copr.fedorainfracloud.org/coprs/) as [`wojnilowicz/ungoogled-chromium`](https://copr.fedorainfracloud.org/coprs/wojnilowicz/ungoogled-chromium/). Also available in [RPM Fusion](https://rpmfusion.org/Configuration) as `chromium-browser-privacy` (outdated).
 * Gentoo: Available in [`::pf4public`](https://github.com/PF4Public/gentoo-overlay) overlay as [`ungoogled-chromium`](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium) and [`ungoogled-chromium-bin`](https://github.com/PF4Public/gentoo-overlay/tree/master/www-client/ungoogled-chromium-bin) ebuilds


### PR DESCRIPTION
See https://github.com/ungoogled-software/ungoogled-chromium-archlinux/commit/32be5fe087d77b2bbb79b76fddc5936ab186f355

The build VM is missing locales which fails the build since some releases and OBS only works on tarballs anyways