### PR TITLE
referrer_sanitizer: export sanitize_referrer function/s

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
+++ b/patches/extra/ungoogled-chromium/add-flags-for-referrer-customization.patch
@@ -193,7 +193,7 @@
 +}  // namespace referrer_sanitizer
 --- /dev/null
 +++ b/services/network/public/cpp/referrer_sanitizer.h
-@@ -0,0 +1,30 @@
+@@ -0,0 +1,32 @@
 +// Copyright 2023 The ungoogled-chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -209,12 +209,14 @@
 +
 +namespace referrer_sanitizer {
 +
++COMPONENT_EXPORT(NETWORK_CPP)
 +std::pair<GURL, net::ReferrerPolicy> sanitize_referrer(
 +    const GURL& origin,
 +    const GURL& destination,
 +    const net::ReferrerPolicy& referrer_policy,
 +    bool enable_referrers);
 +
++COMPONENT_EXPORT(NETWORK_CPP)
 +std::pair<GURL, network::mojom::ReferrerPolicy> sanitize_referrer(
 +    const GURL& origin,
 +    const GURL& destination,


### PR DESCRIPTION
It was not previously exported, which I found out when linking failed when trying to do a component build.

*(Please ensure you have read SUPPORT.md and docs/contributing.md before submitting the Pull Request)*
