### PR TITLE
extensions-manifestv2: re-enable registering experiment factory

### DIFF
--- a/patches/core/ungoogled-chromium/extensions-manifestv2.patch
+++ b/patches/core/ungoogled-chromium/extensions-manifestv2.patch
@@ -79,24 +79,6 @@
  }
  
  bool ExtensionManagement::IsAllowedByUnpublishedAvailabilityPolicy(
---- a/chrome/browser/extensions/keyed_services/chrome_browser_context_keyed_service_factories.cc
-+++ b/chrome/browser/extensions/keyed_services/chrome_browser_context_keyed_service_factories.cc
-@@ -19,7 +19,6 @@
- #include "chrome/browser/extensions/extension_web_ui_override_registrar.h"
- #include "chrome/browser/extensions/install_tracker_factory.h"
- #include "chrome/browser/extensions/install_verifier_factory.h"
--#include "chrome/browser/extensions/manifest_v2_experiment_manager.h"
- #include "chrome/browser/extensions/menu_manager_factory.h"
- #include "chrome/browser/extensions/permissions/permissions_updater.h"
- #include "chrome/browser/extensions/plugin_manager.h"
-@@ -43,7 +42,6 @@ void EnsureChromeBrowserContextKeyedServ
-   extensions::ExtensionWebUIOverrideRegistrar::GetFactoryInstance();
-   extensions::InstallTrackerFactory::GetInstance();
-   extensions::InstallVerifierFactory::GetInstance();
--  extensions::ManifestV2ExperimentManager::GetFactory();
-   extensions::MenuManagerFactory::GetInstance();
-   extensions::PermissionsUpdater::EnsureAssociatedFactoryBuilt();
- #if BUILDFLAG(ENABLE_PLUGINS)
 --- a/chrome/browser/extensions/manifest_v2_experiment_manager.cc
 +++ b/chrome/browser/extensions/manifest_v2_experiment_manager.cc
 @@ -144,22 +144,6 @@ bool ManifestV2ExperimentManagerFactory:


### PR DESCRIPTION
The absence of the GetFactory() call causes the following crash on startup when attempting to run a component/non`official` build:
```
[9001:259:0223/231456.655032:FATAL:dependency_manager.cc(82)] Check failed: false. Trying to register KeyedService Factory: `ManifestV2ExperimentManager` after the call to the main registration function `ChromeBrowserMainExtraPartsProfiles::EnsureBrowserContextKeyedServiceFactoriesBuilt()`. Please add a call your factory `KeyedServiceFactory::GetInstance()` in the previous method or to the appropriate `EnsureBrowserContextKeyedServiceFactoriesBuilt()` function to properly register your factory.
0   libbase.dylib                       0x000000010523307c base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   libbase.dylib                       0x000000010521a8c8 base::debug::StackTrace::StackTrace(unsigned long) + 156
2   libbase.dylib                       0x0000000105131ef0 logging::LogMessage::Flush() + 152
3   libbase.dylib                       0x0000000105131de4 logging::LogMessage::~LogMessage() + 36
4   libbase.dylib                       0x000000010511228c logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 76
5   libbase.dylib                       0x0000000105111ac4 logging::CheckError::~CheckError() + 44
6   libbase.dylib                       0x0000000105111b24 logging::CheckError::~CheckError() + 12
7   libkeyed_service_core.dylib         0x00000001050ccf38 DependencyManager::AddComponent(KeyedServiceBaseFactory*) + 500
8   libkeyed_service_core.dylib         0x00000001050cdbcc KeyedServiceBaseFactory::KeyedServiceBaseFactory(char const*, DependencyManager*, KeyedServiceBaseFactory::Type) + 68
9   libkeyed_service_content.dylib      0x000000011811e9e4 BrowserContextKeyedServiceFactory::BrowserContextKeyedServiceFactory(char const*, BrowserContextDependencyManager*) + 16
10  libchrome_dll.dylib                 0x000000010d61b2b0 ProfileKeyedServiceFactory::ProfileKeyedServiceFactory(char const*, ProfileSelections const&) + 48
11  libchrome_dll.dylib                 0x000000010dca0f14 base::NoDestructor<extensions::(anonymous namespace)::ManifestV2ExperimentManagerFactory>::NoDestructor<>() + 88
12  libchrome_dll.dylib                 0x000000010dca0ea0 extensions::ManifestV2ExperimentManager::Get(content::BrowserContext*) + 76
13  libchrome_dll.dylib                 0x000000010dcb6970 extensions::StandardManagementPolicyProvider::MustRemainDisabled(extensions::Extension const*, extensions::disable_reason::DisableReason*) const + 204
```