### PR TITLE
tracked_persistent_pref: don't use empty validation delegate

### DIFF
--- a/patches/series
+++ b/patches/series
@@ -1,6 +1,7 @@
 upstream-fixes/glue_core_pools.patch
 upstream-fixes/hardware_destructive_interference_size.patch
 upstream-fixes/missing-dependencies.patch
+upstream-fixes/fix-building-without-safe-browsing.patch
 
 core/inox-patchset/0001-fix-building-without-safebrowsing.patch
 core/inox-patchset/0003-disable-autofill-download-manager.patch

--- a/patches/upstream-fixes/fix-building-without-safe-browsing.patch
+++ b/patches/upstream-fixes/fix-building-without-safe-browsing.patch
@@ -1,0 +1,29 @@
+Taken from upstream commit chromium@d9a89d6e5cfa15c2a58091f972ccdd6fde57ebb3.
+
+--- a/services/preferences/tracked/tracked_persistent_pref_store_factory.cc
++++ b/services/preferences/tracked/tracked_persistent_pref_store_factory.cc
+@@ -103,12 +103,18 @@ PersistentPrefStore* CreateTrackedPersis
+   }
+ #endif
+ 
+-  mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>
+-      validation_delegate;
+-  validation_delegate.Bind(std::move(config->validation_delegate));
+-  auto validation_delegate_ref = base::MakeRefCounted<base::RefCountedData<
+-      mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>>>(
+-      std::move(validation_delegate));
++  scoped_refptr<base::RefCountedData<
++      mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>>>
++      validation_delegate_ref;
++  if (config->validation_delegate) {
++    mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>
++        validation_delegate;
++    validation_delegate.Bind(std::move(config->validation_delegate));
++    validation_delegate_ref = base::MakeRefCounted<base::RefCountedData<
++        mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>>>(
++        std::move(validation_delegate));
++  }
++
+   std::unique_ptr<PrefHashFilter> unprotected_pref_hash_filter(
+       new PrefHashFilter(CreatePrefHashStore(*config, false),
+                          GetExternalVerificationPrefHashStorePair(


### PR DESCRIPTION
This is a specific snippet I have taken from chromium/chromium@d9a89d6e5cfa15c2a58091f972ccdd6fde57ebb3, which fixes a crash that happens on launch in a component/non`official` build when safe browsing is disabled. I included only this snippet from the patch since it's pretty large, but if you think I should include anything else, do let me know.

(The motivation behind this is that, while the upstream patch has already landed in >= 135, the stable release is still a month+ away. Once it's out, _this_ patch can just get removed.)