### PR TITLE
various fixes for component builds

### DIFF
--- a/patches/core/ungoogled-chromium/extensions-manifestv2.patch
+++ b/patches/core/ungoogled-chromium/extensions-manifestv2.patch
@@ -79,24 +79,6 @@
  }
  
  bool ExtensionManagement::IsAllowedByUnpublishedAvailabilityPolicy(
---- a/chrome/browser/extensions/keyed_services/chrome_browser_context_keyed_service_factories.cc
-+++ b/chrome/browser/extensions/keyed_services/chrome_browser_context_keyed_service_factories.cc
-@@ -19,7 +19,6 @@
- #include "chrome/browser/extensions/extension_web_ui_override_registrar.h"
- #include "chrome/browser/extensions/install_tracker_factory.h"
- #include "chrome/browser/extensions/install_verifier_factory.h"
--#include "chrome/browser/extensions/manifest_v2_experiment_manager.h"
- #include "chrome/browser/extensions/menu_manager_factory.h"
- #include "chrome/browser/extensions/permissions/permissions_updater.h"
- #include "chrome/browser/extensions/plugin_manager.h"
-@@ -43,7 +42,6 @@ void EnsureChromeBrowserContextKeyedServ
-   extensions::ExtensionWebUIOverrideRegistrar::GetFactoryInstance();
-   extensions::InstallTrackerFactory::GetInstance();
-   extensions::InstallVerifierFactory::GetInstance();
--  extensions::ManifestV2ExperimentManager::GetFactory();
-   extensions::MenuManagerFactory::GetInstance();
-   extensions::PermissionsUpdater::EnsureAssociatedFactoryBuilt();
- #if BUILDFLAG(ENABLE_PLUGINS)
 --- a/chrome/browser/extensions/manifest_v2_experiment_manager.cc
 +++ b/chrome/browser/extensions/manifest_v2_experiment_manager.cc
 @@ -144,22 +144,6 @@ bool ManifestV2ExperimentManagerFactory:

--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -519,7 +519,69 @@
    // Specify the maximum message and title width explicitly.
 --- a/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
 +++ b/chrome/browser/ui/webui/settings/settings_localized_strings_provider.cc
-@@ -3441,7 +3441,7 @@ void AddSiteSettingsStrings(content::Web
+@@ -909,40 +909,20 @@ void AddPerformanceStrings(content::WebU
+        IDS_SETTINGS_PERFORMANCE_TAB_HOVER_PREVIEW_CARD_LINK_SUBTITLE},
+       {"performanceInterventionEnabledLabel",
+        IDS_SETTINGS_PERFORMANCE_INTERVENTION_NOTIFICATION_ENABLED_LABEL},
+-  };
+-  html_source->AddLocalizedStrings(kLocalizedStrings);
+-
+-  static constexpr struct {
+-    const char* id;
+-    int message_id;
+-    const char16_t* url;
+-  } kLearnMoreStrings[] = {
+       {"batterySaverModeDescription",
+-       IDS_SETTINGS_PERFORMANCE_BATTERY_SAVER_MODE_SETTING_DESCRIPTION,
+-       chrome::kBatterySaverModeLearnMoreUrl},
++       IDS_SETTINGS_PERFORMANCE_BATTERY_SAVER_MODE_SETTING_DESCRIPTION},
+       {"discardRingTreatmentEnabledDescriptionWithLearnLink",
+-       IDS_SETTINGS_PERFORMANCE_DISCARD_RING_TREATMENT_ENABLED_DESCRIPTION_WITH_LEARN_LINK,
+-       chrome::kDiscardRingTreatmentLearnMoreUrl},
++       IDS_SETTINGS_PERFORMANCE_DISCARD_RING_TREATMENT_ENABLED_DESCRIPTION_WITH_LEARN_LINK},
+       {"memorySaverModeDescription",
+-       IDS_SETTINGS_PERFORMANCE_MEMORY_SAVER_MODE_SETTING_DESCRIPTION,
+-       chrome::kMemorySaverModeLearnMoreUrl},
++       IDS_SETTINGS_PERFORMANCE_MEMORY_SAVER_MODE_SETTING_DESCRIPTION},
+       {"performanceInterventionEnabledDescription",
+-       IDS_SETTINGS_PERFORMANCE_INTERVENTION_NOTIFICATION_ENABLED_DESCRIPTION,
+-       chrome::kPerformanceInterventionLearnMoreUrl},
++       IDS_SETTINGS_PERFORMANCE_INTERVENTION_NOTIFICATION_ENABLED_DESCRIPTION},
+       {"preloadingToggleSummary",
+-       IDS_SETTINGS_PERFORMANCE_PRELOAD_TOGGLE_SUMMARY,
+-       chrome::kPreloadingLearnMoreUrl}};
+-
+-  const std::u16string settings_opens_in_new_tab =
+-      l10n_util::GetStringUTF16(IDS_SETTINGS_OPENS_IN_NEW_TAB);
+-
+-  for (const auto& learn_more_string : kLearnMoreStrings) {
+-    html_source->AddString(
+-        learn_more_string.id,
+-        l10n_util::GetStringFUTF16(learn_more_string.message_id,
+-                                   learn_more_string.url,
+-                                   settings_opens_in_new_tab));
+-  }
++       IDS_SETTINGS_PERFORMANCE_PRELOAD_TOGGLE_SUMMARY},
++      {"tabDiscardingExceptionsAddDialogHelp",
++       IDS_SETTINGS_PERFORMANCE_TAB_DISCARDING_EXCEPTIONS_ADD_DIALOG_HELP},
++  };
++  html_source->AddLocalizedStrings(kLocalizedStrings);
+ 
+   html_source->AddString(
+       "tabDiscardTimerFiveMinutes",
+@@ -988,11 +968,6 @@ void AddPerformanceStrings(content::WebU
+           base::NumberToString16(
+               performance_manager::user_tuning::BatterySaverModeManager::
+                   kLowBatteryThresholdPercent)));
+-  html_source->AddString(
+-      "tabDiscardingExceptionsAddDialogHelp",
+-      l10n_util::GetStringFUTF16(
+-          IDS_SETTINGS_PERFORMANCE_TAB_DISCARDING_EXCEPTIONS_ADD_DIALOG_HELP,
+-          chrome::kMemorySaverModeTabDiscardingHelpUrl));
+ 
+   html_source->AddString("discardRingTreatmentLearnMoreUrl",
+                          chrome::kDiscardRingTreatmentLearnMoreUrl);
+@@ -3441,7 +3416,7 @@ void AddSiteSettingsStrings(content::Web
        base::FeatureList::IsEnabled(blink::features::kWebPrinting));
  
    html_source->AddBoolean("enableFederatedIdentityApiContentSetting",

--- a/patches/series
+++ b/patches/series
@@ -1,6 +1,7 @@
 upstream-fixes/glue_core_pools.patch
 upstream-fixes/hardware_destructive_interference_size.patch
 upstream-fixes/missing-dependencies.patch
+upstream-fixes/fix-building-without-safe-browsing.patch
 
 core/inox-patchset/0001-fix-building-without-safebrowsing.patch
 core/inox-patchset/0003-disable-autofill-download-manager.patch

--- a/patches/upstream-fixes/fix-building-without-safe-browsing.patch
+++ b/patches/upstream-fixes/fix-building-without-safe-browsing.patch
@@ -1,0 +1,29 @@
+Taken from upstream commit chromium@d9a89d6e5cfa15c2a58091f972ccdd6fde57ebb3.
+
+--- a/services/preferences/tracked/tracked_persistent_pref_store_factory.cc
++++ b/services/preferences/tracked/tracked_persistent_pref_store_factory.cc
+@@ -103,12 +103,18 @@ PersistentPrefStore* CreateTrackedPersis
+   }
+ #endif
+ 
+-  mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>
+-      validation_delegate;
+-  validation_delegate.Bind(std::move(config->validation_delegate));
+-  auto validation_delegate_ref = base::MakeRefCounted<base::RefCountedData<
+-      mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>>>(
+-      std::move(validation_delegate));
++  scoped_refptr<base::RefCountedData<
++      mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>>>
++      validation_delegate_ref;
++  if (config->validation_delegate) {
++    mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>
++        validation_delegate;
++    validation_delegate.Bind(std::move(config->validation_delegate));
++    validation_delegate_ref = base::MakeRefCounted<base::RefCountedData<
++        mojo::Remote<prefs::mojom::TrackedPreferenceValidationDelegate>>>(
++        std::move(validation_delegate));
++  }
++
+   std::unique_ptr<PrefHashFilter> unprotected_pref_hash_filter(
+       new PrefHashFilter(CreatePrefHashStore(*config, false),
+                          GetExternalVerificationPrefHashStorePair(


### PR DESCRIPTION
### extensions-manifestv2: re-enable registering experiment factory (#3210)
The absence of the GetFactory() call causes the following crash on startup when attempting to run a component/non`official` build:
```
[9001:259:0223/231456.655032:FATAL:dependency_manager.cc(82)] Check failed: false. Trying to register KeyedService Factory: `ManifestV2ExperimentManager` after the call to the main registration function `ChromeBrowserMainExtraPartsProfiles::EnsureBrowserContextKeyedServiceFactoriesBuilt()`. Please add a call your factory `KeyedServiceFactory::GetInstance()` in the previous method or to the appropriate `EnsureBrowserContextKeyedServiceFactoriesBuilt()` function to properly register your factory.
0   libbase.dylib                       0x000000010523307c base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   libbase.dylib                       0x000000010521a8c8 base::debug::StackTrace::StackTrace(unsigned long) + 156
2   libbase.dylib                       0x0000000105131ef0 logging::LogMessage::Flush() + 152
3   libbase.dylib                       0x0000000105131de4 logging::LogMessage::~LogMessage() + 36
4   libbase.dylib                       0x000000010511228c logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 76
5   libbase.dylib                       0x0000000105111ac4 logging::CheckError::~CheckError() + 44
6   libbase.dylib                       0x0000000105111b24 logging::CheckError::~CheckError() + 12
7   libkeyed_service_core.dylib         0x00000001050ccf38 DependencyManager::AddComponent(KeyedServiceBaseFactory*) + 500
8   libkeyed_service_core.dylib         0x00000001050cdbcc KeyedServiceBaseFactory::KeyedServiceBaseFactory(char const*, DependencyManager*, KeyedServiceBaseFactory::Type) + 68
9   libkeyed_service_content.dylib      0x000000011811e9e4 BrowserContextKeyedServiceFactory::BrowserContextKeyedServiceFactory(char const*, BrowserContextDependencyManager*) + 16
10  libchrome_dll.dylib                 0x000000010d61b2b0 ProfileKeyedServiceFactory::ProfileKeyedServiceFactory(char const*, ProfileSelections const&) + 48
11  libchrome_dll.dylib                 0x000000010dca0f14 base::NoDestructor<extensions::(anonymous namespace)::ManifestV2ExperimentManagerFactory>::NoDestructor<>() + 88
12  libchrome_dll.dylib                 0x000000010dca0ea0 extensions::ManifestV2ExperimentManager::Get(content::BrowserContext*) + 76
13  libchrome_dll.dylib                 0x000000010dcb6970 extensions::StandardManagementPolicyProvider::MustRemainDisabled(extensions::Extension const*, extensions::disable_reason::DisableReason*) const + 204
```

### tracked_persistent_pref: don't use empty validation delegate (#3211)

This is a specific snippet I have taken from chromium/chromium@d9a89d6e5cfa15c2a58091f972ccdd6fde57ebb3, which fixes a crash that happens on launch in a component/non`official` build when safe browsing is disabled. I included only this snippet from the patch since it's pretty large, but if you think I should include anything else, do let me know.

(The motivation behind this is that, while the upstream patch has already landed in >= 135, the stable release is still a month+ away. Once it's out, _this_ patch can just get removed.)

### settings/strings: don't format strings that have no placeholders

Fixes another DCHECK crash (when opening settings):
```
[28934:259:0224/010009.574147:FATAL:l10n_util.cc(837)] Check failed: std::string::npos != pos (18446744073709551615 vs. 18446744073709551615) Didn't find a $1 placeholder in Chromium conserves battery power by limiting background activity and visual effects, such as smooth scrolling and video frame rates.
0   libbase.dylib                       0x0000000104d1307c base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   libbase.dylib                       0x0000000104cfa8c8 base::debug::StackTrace::StackTrace(unsigned long) + 156
2   libbase.dylib                       0x0000000104c11ef0 logging::LogMessage::Flush() + 152
3   libbase.dylib                       0x0000000104c11de4 logging::LogMessage::~LogMessage() + 36
4   libbase.dylib                       0x0000000104bf228c logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 76
5   libbase.dylib                       0x0000000104bf1ac4 logging::CheckError::~CheckError() + 44
6   libbase.dylib                       0x0000000104bf1b24 logging::CheckError::~CheckError() + 12
7   libui_base.dylib                    0x0000000108a55304 l10n_util::FormatString(std::__Cr::basic_string<char16_t, std::__Cr::char_traits<char16_t>, std::__Cr::allocator<char16_t>> const&, std::__Cr::vector<std::__Cr::basic_string<char16_t, std::__Cr::char_traits<char16_t>, std::__Cr::allocator<char16_t>>, std::__Cr::allocator<std::__Cr::basic_string<char16_t, std::__Cr::char_traits<char16_t>, std::__Cr::allocator<char16_t>>>> const&, std::__Cr::vector<unsigned long, std::__Cr::allocator<unsigned long>>*) + 708
8   libui_base.dylib                    0x0000000108a55f68 l10n_util::GetStringFUTF16(int, std::__Cr::basic_string<char16_t, std::__Cr::char_traits<char16_t>, std::__Cr::allocator<char16_t>> const&, std::__Cr::basic_string<char16_t, std::__Cr::char_traits<char16_t>, std::__Cr::allocator<char16_t>> const&, std::__Cr::vector<unsigned long, std::__Cr::allocator<unsigned long>>*) + 360
9   libchrome_dll.dylib                 0x000000010f0af19c settings::AddLocalizedStrings(content::WebUIDataSource*, Profile*, content::WebContents*) + 5048

```