### PR TITLE
patches/webgl: return generic info instead of empty strings

### DIFF
--- a/patches/extra/ungoogled-chromium/spoof-webgl-renderer-info.patch
+++ b/patches/extra/ungoogled-chromium/spoof-webgl-renderer-info.patch
@@ -1,25 +1,24 @@
-# Return blank values for WebGLDebugRendererInfo to remove a potential data
+# Return generic values for WebGLDebugRendererInfo to remove a potential data
 # leak while preventing potential website breakage
 
 --- a/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
 +++ b/third_party/blink/renderer/modules/webgl/webgl_rendering_context_base.cc
-@@ -3833,8 +3833,7 @@ ScriptValue WebGLRenderingContextBase::g
-               pname, IdentifiabilityBenignStringToken(
+@@ -3834,7 +3834,7 @@ ScriptValue WebGLRenderingContextBase::g
                           String(ContextGL()->GetString(GL_RENDERER))));
          }
--        return WebGLAny(script_state,
+         return WebGLAny(script_state,
 -                        String(ContextGL()->GetString(GL_RENDERER)));
-+        return WebGLAny(script_state, String(""));
++                        String("ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero) (0x0000C0DE)), SwiftShader driver-5.0.0)"));
        }
        SynthesizeGLError(
            GL_INVALID_ENUM, "getParameter",
-@@ -3848,8 +3847,7 @@ ScriptValue WebGLRenderingContextBase::g
+@@ -3848,8 +3848,7 @@ ScriptValue WebGLRenderingContextBase::g
                pname, IdentifiabilityBenignStringToken(
                           String(ContextGL()->GetString(GL_VENDOR))));
          }
 -        return WebGLAny(script_state,
 -                        String(ContextGL()->GetString(GL_VENDOR)));
-+        return WebGLAny(script_state, String(""));
++        return WebGLAny(script_state, String("Google Inc. (Google)"));
        }
        SynthesizeGLError(
            GL_INVALID_ENUM, "getParameter",

--- a/patches/series
+++ b/patches/series
@@ -64,7 +64,7 @@ extra/ungoogled-chromium/add-flag-to-configure-extension-downloading.patch
 extra/ungoogled-chromium/add-flag-for-search-engine-collection.patch
 extra/ungoogled-chromium/add-flag-to-disable-beforeunload.patch
 extra/ungoogled-chromium/add-flag-to-force-punycode-hostnames.patch
-extra/ungoogled-chromium/disable-webgl-renderer-info.patch
+extra/ungoogled-chromium/spoof-webgl-renderer-info.patch
 extra/ungoogled-chromium/add-flag-to-show-avatar-button.patch
 extra/ungoogled-chromium/add-suggestions-url-field.patch
 extra/ungoogled-chromium/add-flag-to-hide-crashed-bubble.patch


### PR DESCRIPTION
Instead of returning empty strings for WebGL info, return a generic renderer & vendor taken from Windows 10 [[1]](https://chromium.googlesource.com/angle/angle/+/main/doc/ExtensionSupport.md) [[2]](https://android.googlesource.com/platform/external/angle/+/b526112daf/scripts/extension_data/swiftshader_win10.json).

Seemingly fixes #3012