### PR TITLE
pruning: update openscreen contingent path

### DIFF
--- a/pruning.list
+++ b/pruning.list
@@ -12610,7 +12610,6 @@ third_party/openh264/src/res/test_qcif_cabac.264
 third_party/openh264/src/res/test_scalinglist_jm.264
 third_party/openh264/src/res/test_vd_1d.264
 third_party/openh264/src/res/test_vd_rc.264
-third_party/openscreen/src/buildtools/linux64-format/clang-format
 third_party/openscreen/src/buildtools/third_party/eu-strip/bin/eu-strip
 third_party/openscreen/src/cast/common/channel/message_framer_fuzzer_seeds/03d4b4028b559489768e2cccd6015c907f70a2c0
 third_party/openscreen/src/cast/common/channel/message_framer_fuzzer_seeds/333be5dfffb2c6eeadf31be2dc219ef841c99ea0

--- a/utils/prune_binaries.py
+++ b/utils/prune_binaries.py
@@ -40,7 +40,7 @@ CONTINGENT_PATHS = (
     'buildtools/linux64-format/',
     'third_party/blink/renderer/core/css/perftest_data/',
     'third_party/js_code_coverage/',
-    'third_party/openscreen/src/buildtools/linux64/format/',
+    'third_party/openscreen/src/buildtools/linux64-format/',
     'third_party/opus/tests/resources/',
     'third_party/subresource-filter-ruleset/data/',
     'tools/perf/page_sets/maps_perf_test/dataset/',


### PR DESCRIPTION
Currently, when trying to build from a fresh clone (not a tarball), I am seeing the following error when pruning binaries:
```
ERROR: 1 files could not be pruned:
third_party/openscreen/src/buildtools/linux64-format/clang-format
```

This is because the `openscreen` third party module changed the path for this binary from `linux64/format/clang-format` to `linux64-format/clang-format`, which means it ended up on the pruning list even though it's not present in the Chromium git repo. This PR updates the CONTINGENT_PATHS to consider this new updated path.