### PR TITLE
Windows-specific improvements (ARM64 and Python)

### DIFF
--- a/utils/clone.py
+++ b/utils/clone.py
@@ -268,7 +268,7 @@ def main():
     parser.add_argument('-p',
                         '--pgo',
                         default='linux',
-                        choices=('linux', 'mac', 'mac-arm', 'win32', 'win64'),
+                        choices=('linux', 'mac', 'mac-arm', 'win32', 'win64', 'win-arm64'),
                         help='Specifiy which pgo profile to download.  Default: %(default)s')
     parser.add_argument('-s',
                         '--sysroot',

--- a/utils/depot_tools.patch
+++ b/utils/depot_tools.patch
@@ -115,3 +115,11 @@
  
  # Google OAuth Context required by gsutil.
  LUCI_AUTH_SCOPES = [
+--- a/gclient.bat
++++ b/gclient.bat
+@@ -20,4 +20,4 @@ IF %ERRORLEVEL% NEQ 0 (
+ set PATH=%PATH%;%~dp0
+ 
+ :: Defer control.
+-call vpython3 "%~dp0gclient.py" %*
++call python3 "%~dp0gclient.py" %*


### PR DESCRIPTION
This pull request does the following:
* Enables downloading PGO profiles for Win-ARM64 builds.
* Forces `gclient.bat` to call system Python directly instead of Google's vpython scripts.

The second one is primarily due to [missing httplib2](https://github.com/ungoogled-software/ungoogled-chromium-windows/issues/349), which I have been hitting repeatedly, despite having it installed. This could be fixed simply by explicitly calling the `vpython.bat` file, but it would be better to skip that and call `python3` directly.