### PR TITLE
patches/webgl-renderer: export spoof value constants

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-to-spoof-webgl-renderer-info.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-spoof-webgl-renderer-info.patch
@@ -77,10 +77,10 @@
  BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kReducedSystemInfo);
  BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kRemoveClientHints);
 +BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kSpoofWebGLInfo);
-+extern const char kSpoofWebGLRenderer[];
-+extern const char kSpoofWebGLVendor[];
-+extern const base::FeatureParam<std::string> kSpoofWebGLRendererParam;
-+extern const base::FeatureParam<std::string> kSpoofWebGLVendorParam;
++BLINK_COMMON_EXPORT extern const char kSpoofWebGLRenderer[];
++BLINK_COMMON_EXPORT extern const char kSpoofWebGLVendor[];
++BLINK_COMMON_EXPORT extern const base::FeatureParam<std::string> kSpoofWebGLRendererParam;
++BLINK_COMMON_EXPORT extern const base::FeatureParam<std::string> kSpoofWebGLVendorParam;
  
  // -----------------------------------------------------------------------------
  // Feature declarations and associated constants (feature params, et cetera)


### PR DESCRIPTION
Fixes a component build build error:
```
ld64.lld: error: undefined symbol: blink::features::kSpoofWebGLVendorParam
>>> referenced by obj/third_party/blink/renderer/modules/webgl/webgl/webgl_rendering_context_base.o:(symbol blink::WebGLRenderingContextBase::getParameter(blink::ScriptState*, unsigned int)+0xfac)
>>> referenced by obj/third_party/blink/renderer/modules/webgl/webgl/webgl_rendering_context_base.o:(symbol blink::WebGLRenderingContextBase::getParameter(blink::ScriptState*, unsigned int)+0xfa8)

ld64.lld: error: undefined symbol: blink::features::kSpoofWebGLRendererParam
>>> referenced by obj/third_party/blink/renderer/modules/webgl/webgl/webgl_rendering_context_base.o:(symbol blink::WebGLRenderingContextBase::getParameter(blink::ScriptState*, unsigned int)+0x564)
>>> referenced by obj/third_party/blink/renderer/modules/webgl/webgl/webgl_rendering_context_base.o:(symbol blink::WebGLRenderingContextBase::getParameter(blink::ScriptState*, unsigned int)+0x560)

```