### PR TITLE
patches/ui: fix crash caused by removed other_node_menu_separator_

### DIFF
--- a/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
+++ b/patches/extra/ungoogled-chromium/remove-uneeded-ui.patch
@@ -404,21 +404,21 @@
  ////////////////////////////////////////////////////////////////////////////////
 --- a/chrome/browser/ui/views/bookmarks/bookmark_menu_delegate.cc
 +++ b/chrome/browser/ui/views/bookmarks/bookmark_menu_delegate.cc
-@@ -1234,15 +1234,4 @@ void BookmarkMenuDelegate::BuildOtherNod
-   ui::ImageModel bookmarks_side_panel_icon = ui::ImageModel::FromVectorIcon(
-       kBookmarksSidePanelIcon, ui::kColorMenuIcon,
-       ui::SimpleMenuModel::kDefaultIconSize);
--  menu->AppendMenuItem(
--      IDC_SHOW_BOOKMARK_SIDE_PANEL,
--      l10n_util::GetStringUTF16(IDS_BOOKMARKS_ALL_BOOKMARKS_OPEN_SIDE_PANEL),
+@@ -1237,12 +1237,14 @@ void BookmarkMenuDelegate::BuildOtherNod
+   menu->AppendMenuItem(
+       IDC_SHOW_BOOKMARK_SIDE_PANEL,
+       l10n_util::GetStringUTF16(IDS_BOOKMARKS_ALL_BOOKMARKS_OPEN_SIDE_PANEL),
 -      bookmarks_side_panel_icon);
--  bool other_folder_children_count =
--      GetBookmarkMergedSurfaceService()->GetChildrenCount(
--          BookmarkParentFolder::OtherFolder());
--  if (other_folder_children_count) {
--    menu->AppendSeparator();
--    other_node_menu_separator_ = menu->GetSubmenu()->children().back().get();
--  }
++      bookmarks_side_panel_icon)->SetVisible(false);
++
+   bool other_folder_children_count =
+       GetBookmarkMergedSurfaceService()->GetChildrenCount(
+           BookmarkParentFolder::OtherFolder());
+   if (other_folder_children_count) {
+     menu->AppendSeparator();
+     other_node_menu_separator_ = menu->GetSubmenu()->children().back().get();
++    other_node_menu_separator_->SetVisible(false);
+   }
  }
 --- a/chrome/browser/ui/views/location_bar/cookie_controls/cookie_controls_content_view.cc
 +++ b/chrome/browser/ui/views/location_bar/cookie_controls/cookie_controls_content_view.cc


### PR DESCRIPTION
fixes crash described in https://github.com/ungoogled-software/ungoogled-chromium/issues/3302#issuecomment-2855143377

I tried removing the CHECK() and related stuff, but it seemed to have just broken even more stuff -- so this might be a better way forward