### PR TITLE
Remove the F1 shortcut + Add an optional tweak for Incognito/Guest profiles

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -69,6 +69,7 @@ These are also available on the `chrome://flags` page.
   `RemoveClientHints` | Removes client hints (information sent to servers about your system, similar to a user agent).
   `SetIpv6ProbeFalse` | Forces the result of the browser's IPv6 probing (i.e. IPv6 connectivity test) to be unsuccessful. This causes IPv4 addresses to be prioritized over IPv6 addresses. Without this flag, the probing result is set to be successful, which causes IPv6 to be used over IPv4 when possible.
   `SpoofWebGLInfo` | Return generic values for WebGLDebugRendererInfo to remove a potential data leak while preventing potential website breakage.
+  `IncreaseIncognitoStorageQuota` | Makes Incognito and Guest profiles compute the storage quota with the same algorithm that regular profiles use. This makes it harder for websites to detect Incognito mode, but may allow sites to induce heavy memory pressure.
 
 - ### Available only on desktop
 

--- a/patches/core/ungoogled-chromium/remove-f1-shortcut.patch
+++ b/patches/core/ungoogled-chromium/remove-f1-shortcut.patch
@@ -1,0 +1,10 @@
+--- a/chrome/browser/ui/views/accelerator_table.cc
++++ b/chrome/browser/ui/views/accelerator_table.cc
+@@ -132,7 +132,6 @@ const AcceleratorMapping kAcceleratorMap
+     {ui::VKEY_OEM_PLUS, ui::EF_PLATFORM_ACCELERATOR, IDC_ZOOM_PLUS},
+     {ui::VKEY_ADD, ui::EF_PLATFORM_ACCELERATOR, IDC_ZOOM_PLUS},
+ 
+-    {ui::VKEY_F1, ui::EF_NONE, IDC_HELP_PAGE_VIA_KEYBOARD},
+     {ui::VKEY_F3, ui::EF_NONE, IDC_FIND_NEXT},
+     {ui::VKEY_F3, ui::EF_SHIFT_DOWN, IDC_FIND_PREVIOUS},
+     {ui::VKEY_F4, ui::EF_CONTROL_DOWN, IDC_CLOSE_TAB},

--- a/patches/extra/ungoogled-chromium/add-flag-to-increase-incognito-storage-quota.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-to-increase-incognito-storage-quota.patch
@@ -1,0 +1,65 @@
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -144,4 +144,8 @@
+      "Spoof WebGL Info",
+      "Return generic values for WebGLDebugRendererInfo to remove a potential data leak while preventing potential website breakage. ungoogled-chromium flag.",
+      kOsAll, FEATURE_WITH_PARAMS_VALUE_TYPE(blink::features::kSpoofWebGLInfo, kSpoofWebGLChoices, "SpoofWebGLInfo")},
++    {"increase-incognito-storage-quota",
++     "Increases the storage quota for Incognito and Guest profiles",
++     "Makes Incognito and Guest profiles compute the storage quota with the same algorithm that regular profiles use. This makes it harder for websites to detect Incognito mode, but may allow sites to induce heavy memory pressure. ungoogled-chromium flag.",
++     kOsAll, FEATURE_VALUE_TYPE(storage::features::kIncreaseIncognitoStorageQuota)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_
+--- a/storage/browser/quota/quota_features.cc
++++ b/storage/browser/quota/quota_features.cc
+@@ -41,5 +41,9 @@ BASE_FEATURE(kStaticStorageQuota,
+              "StaticStorageQuota",
+              base::FEATURE_DISABLED_BY_DEFAULT);
+ 
++BASE_FEATURE(kIncreaseIncognitoStorageQuota,
++             "IncreaseIncognitoStorageQuota",
++             base::FEATURE_DISABLED_BY_DEFAULT);
++
+ }  // namespace features
+ }  // namespace storage
+--- a/storage/browser/quota/quota_features.h
++++ b/storage/browser/quota/quota_features.h
+@@ -23,6 +23,8 @@ extern const base::FeatureParam<double>
+ 
+ COMPONENT_EXPORT(STORAGE_BROWSER) BASE_DECLARE_FEATURE(kStaticStorageQuota);
+ 
++COMPONENT_EXPORT(STORAGE_BROWSER) BASE_DECLARE_FEATURE(kIncreaseIncognitoStorageQuota);
++
+ }  // namespace features
+ 
+ }  // namespace storage
+--- a/storage/browser/quota/quota_settings.cc
++++ b/storage/browser/quota/quota_settings.cc
+@@ -9,6 +9,7 @@
+ #include <memory>
+ #include <utility>
+ 
++#include "base/feature_list.h"
+ #include "base/functional/bind.h"
+ #include "base/no_destructor.h"
+ #include "base/numerics/safe_conversions.h"
+@@ -55,7 +56,8 @@ std::optional<QuotaSettings> CalculateNo
+   base::ScopedBlockingCall scoped_blocking_call(FROM_HERE,
+                                                 base::BlockingType::MAY_BLOCK);
+ 
+-  if (is_incognito) {
++  if (is_incognito &&
++      !base::FeatureList::IsEnabled(features::kIncreaseIncognitoStorageQuota)) {
+     return CalculateIncognitoDynamicSettings(
+         device_info_helper->AmountOfPhysicalMemory());
+   }
+@@ -116,7 +118,9 @@ std::optional<QuotaSettings> CalculateNo
+ 
+   QuotaSettings settings;
+ 
+-  int64_t total = device_info_helper->AmountOfTotalDiskSpace(partition_path);
++  int64_t total =
++      is_incognito ? device_info_helper->AmountOfPhysicalMemory()
++                   : device_info_helper->AmountOfTotalDiskSpace(partition_path);
+   if (total == -1) {
+     LOG(ERROR) << "Unable to compute QuotaSettings.";
+     return std::nullopt;

--- a/patches/series
+++ b/patches/series
@@ -110,3 +110,4 @@ extra/ungoogled-chromium/disable-chromelabs.patch
 extra/ungoogled-chromium/remove-pac-size-limit.patch
 extra/ungoogled-chromium/enable-certificate-transparency-and-add-flag.patch
 extra/ungoogled-chromium/add-flag-to-spoof-webgl-renderer-info.patch
+extra/ungoogled-chromium/add-flag-to-increase-incognito-storage-quota.patch

--- a/patches/series
+++ b/patches/series
@@ -33,6 +33,7 @@ core/ungoogled-chromium/block-requests.patch
 core/ungoogled-chromium/disable-privacy-sandbox.patch
 core/ungoogled-chromium/doh-changes.patch
 core/ungoogled-chromium/extensions-manifestv2.patch
+core/ungoogled-chromium/remove-f1-shortcut.patch
 core/bromite/disable-fetching-field-trials.patch
 
 extra/ungoogled-chromium/add-ungoogled-flag-headers.patch


### PR DESCRIPTION
The first change here removes the F1 shortcut, which just tries to open a Google help page (unless you're on macOS, where it does nothing since this block of code is `#ifdef`ed out there).

The second change adds a new flag that allows increasing the storage quota for Incognito/Guest (aka OTR / off-the-record) profiles. The point of this is that makes it harder for sites to detect that you're browsing in Incognito mode (because it feels pretty invasive when they do that). This works because AFAIK these days the only remaining clear indicator that you're using Incognito mode is the extremely small quota size there, which can be obtained through various browser APIs as well as probably many side-channels.
Concretely, this patch allows you to get a higher quota by switching to the same algorithm that's used for "regular" profiles. Naturally, you'll need a fair amount of ram to overcome whatever thresholds scripts use as the cutoff point, but at least 8GiB should be enough to trick the most popular library.