### PR TITLE
Update CI config, scripts, and docs for python 3.10

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,7 +9,7 @@ container:
 
 code_check_task:
     pip_cache:
-        folder: /usr/local/lib/python3.9/site-packages
+        folder: /usr/local/lib/python3.10/site-packages
         fingerprint_script: cat .cirrus_requirements.txt
         populate_script: pip install -r .cirrus_requirements.txt
     utils_script:
@@ -26,7 +26,7 @@ validate_config_task:
 
 validate_with_source_task:
     pip_cache:
-        folder: /usr/local/lib/python3.9/site-packages
+        folder: /usr/local/lib/python3.10/site-packages
         fingerprint_script: cat .cirrus_requirements.txt
         populate_script: pip install -r .cirrus_requirements.txt
     chromium_download_script: |

--- a/.cirrus_Dockerfile
+++ b/.cirrus_Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for Python 3 with xz-utils (for tar.xz unpacking)
 
-FROM python:3.9-slim-bullseye
+FROM python:3.10-slim-bookworm
 
 RUN apt update && apt install -y xz-utils patch axel curl git

--- a/.cirrus_requirements.txt
+++ b/.cirrus_requirements.txt
@@ -1,9 +1,9 @@
-# Based on Python package versions in Debian bullseye
-# https://packages.debian.org/bullseye/python/
-astroid==2.5.1 # via pylint
-pylint==2.7.2
-pytest-cov==2.10.1
-pytest==6.0.2
-httplib2==0.18.1
-requests==2.25.1
-yapf==0.30.0
+# Based on Python package versions in Debian bookworm
+# https://packages.debian.org/bookworm/python/
+astroid==2.14.2 # via pylint
+pylint==2.16.2
+pytest-cov==4.0.0
+pytest==7.2.1
+httplib2==0.20.4
+requests==2.28.1
+yapf==0.32.0

--- a/devutils/check_downloads_ini.py
+++ b/devutils/check_downloads_ini.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'utils'))
 from downloads import DownloadInfo, schema
+
 sys.path.pop(0)
 
 

--- a/devutils/check_files_exist.py
+++ b/devutils/check_files_exist.py
@@ -27,8 +27,7 @@ def main():
                      Path(input_name).read_text(encoding='UTF-8').splitlines()))
         for file_name in file_iter:
             if not Path(args.root_dir, file_name).exists():
-                print('ERROR: Path "{}" from file "{}" does not exist.'.format(
-                    file_name, input_name),
+                print(f'ERROR: Path "{file_name}" from file "{input_name}" does not exist.',
                       file=sys.stderr)
                 sys.exit(1)
 

--- a/devutils/check_gn_flags.py
+++ b/devutils/check_gn_flags.py
@@ -21,6 +21,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'utils'))
 from _common import ENCODING, get_logger
+
 sys.path.pop(0)
 
 

--- a/devutils/check_patch_files.py
+++ b/devutils/check_patch_files.py
@@ -24,6 +24,7 @@ from third_party import unidiff
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'utils'))
 from _common import ENCODING, get_logger, parse_series # pylint: disable=wrong-import-order
+
 sys.path.pop(0)
 
 # File suffixes to ignore for checking unused patches

--- a/devutils/run_devutils_pylint.py
+++ b/devutils/run_devutils_pylint.py
@@ -23,7 +23,6 @@ def main():
 
     disables = [
         'wrong-import-position',
-        'bad-continuation',
         'duplicate-code',
     ]
 
@@ -33,7 +32,7 @@ def main():
         disables.append('locally-disabled')
 
     pylint_options = [
-        '--disable={}'.format(','.join(disables)),
+        f"--disable={','.join(disables)}",
         '--jobs=4',
         '--score=n',
         '--persistent=n',

--- a/devutils/run_other_pylint.py
+++ b/devutils/run_other_pylint.py
@@ -18,6 +18,7 @@ class ChangeDir:
     """
     Changes directory to path in with statement
     """
+
     def __init__(self, path):
         self._path = path
         self._orig_path = os.getcwd()
@@ -31,12 +32,12 @@ class ChangeDir:
 
 def run_pylint(module_path, pylint_options, ignore_prefixes=tuple()):
     """Runs Pylint. Returns a boolean indicating success"""
-    pylint_stats = Path('/run/user/{}/pylint_stats'.format(os.getuid()))
+    pylint_stats = Path(f'/run/user/{os.getuid()}/pylint_stats')
     if not pylint_stats.parent.is_dir(): #pylint: disable=no-member
         pylint_stats = Path('/run/shm/pylint_stats')
     os.environ['PYLINTHOME'] = str(pylint_stats)
 
-    input_paths = list()
+    input_paths = []
     if not module_path.exists():
         print('ERROR: Cannot find', module_path)
         sys.exit(1)
@@ -75,12 +76,11 @@ def main():
     args = parser.parse_args()
 
     if not args.module_path.exists():
-        print('ERROR: Module path "{}" does not exist'.format(args.module_path))
+        print(f'ERROR: Module path "{args.module_path}" does not exist')
         sys.exit(1)
 
     disables = [
         'wrong-import-position',
-        'bad-continuation',
     ]
 
     if args.hide_fixme:
@@ -89,7 +89,7 @@ def main():
         disables.append('locally-disabled')
 
     pylint_options = [
-        '--disable={}'.format(','.join(disables)),
+        f"--disable={','.join(disables)}",
         '--jobs=4',
         '--score=n',
         '--persistent=n',

--- a/devutils/run_utils_pylint.py
+++ b/devutils/run_utils_pylint.py
@@ -21,20 +21,17 @@ def main():
                         help='Show "locally-disabled" Pylint warnings.')
     args = parser.parse_args()
 
-    disable = ['bad-continuation']
-
-    if args.hide_fixme:
-        disable.append('fixme')
-    if not args.show_locally_disabled:
-        disable.append('locally-disabled')
-
     pylint_options = [
-        '--disable={}'.format(','.join(disable)),
         '--jobs=4',
         '--max-args=7',
         '--score=n',
         '--persistent=n',
     ]
+
+    if args.hide_fixme:
+        pylint_options.append('--disable=fixme')
+    if not args.show_locally_disabled:
+        pylint_options.append('--disable=locally-disabled')
 
     ignore_prefixes = [
         ('third_party', ),

--- a/devutils/tests/test_check_patch_files.py
+++ b/devutils/tests/test_check_patch_files.py
@@ -11,11 +11,13 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / 'utils'))
-from _common import get_logger, set_logging_level
+from _common import ENCODING, get_logger, set_logging_level
+
 sys.path.pop(0)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 from check_patch_files import check_series_duplicates
+
 sys.path.pop(0)
 
 
@@ -33,7 +35,7 @@ def test_check_series_duplicates():
             'a.patch',
             'b.patch',
             'c.patch',
-        ]))
+        ]), encoding=ENCODING)
         assert not check_series_duplicates(patches_dir)
 
         get_logger().info('Check duplicates')
@@ -42,7 +44,8 @@ def test_check_series_duplicates():
             'b.patch',
             'c.patch',
             'a.patch',
-        ]))
+        ]),
+                               encoding=ENCODING)
         assert check_series_duplicates(patches_dir)
 
 

--- a/devutils/tests/test_validate_patches.py
+++ b/devutils/tests/test_validate_patches.py
@@ -11,11 +11,13 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / 'utils'))
-from _common import get_logger, set_logging_level
+from _common import ENCODING, get_logger, set_logging_level
+
 sys.path.pop(0)
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import validate_patches
+
 sys.path.pop(0)
 
 
@@ -30,8 +32,8 @@ def test_test_patches():
 
     def _run_test_patches(patch_content):
         with tempfile.TemporaryDirectory() as tmpdirname:
-            Path(tmpdirname, 'foobar.txt').write_text(orig_file_content)
-            Path(tmpdirname, 'test.patch').write_text(patch_content)
+            Path(tmpdirname, 'foobar.txt').write_text(orig_file_content, encoding=ENCODING)
+            Path(tmpdirname, 'test.patch').write_text(patch_content, encoding=ENCODING)
             _, patch_cache = validate_patches._load_all_patches(series_iter, Path(tmpdirname))
             required_files = validate_patches._get_required_files(patch_cache)
             files_under_test = validate_patches._retrieve_local_files(required_files,

--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'utils'))
 from _common import get_logger
 from domain_substitution import DomainRegexList, TREE_ENCODINGS
 from prune_binaries import CONTINGENT_PATHS
+
 sys.path.pop(0)
 
 # Encoding for output files
@@ -383,9 +384,9 @@ def main(args_list=None):
         args.tree,
         DomainRegexList(args.domain_regex).search_regex, args.processes)
     with args.pruning.open('w', encoding=_ENCODING) as file_obj:
-        file_obj.writelines('%s\n' % line for line in pruning_set)
+        file_obj.writelines(f'{line}\n' for line in pruning_set)
     with args.domain_substitution.open('w', encoding=_ENCODING) as file_obj:
-        file_obj.writelines('%s\n' % line for line in domain_substitution_set)
+        file_obj.writelines(f'{line}\n' for line in domain_substitution_set)
     if unused_patterns.log_unused(args.error_unused) and args.error_unused:
         get_logger().error('Please update or remove unused patterns and/or prefixes. '
                            'The lists have still been updated with the remaining valid entries.')

--- a/devutils/update_platform_patches.py
+++ b/devutils/update_platform_patches.py
@@ -17,6 +17,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / 'utils'))
 from _common import ENCODING, get_logger
 from patches import merge_patches
+
 sys.path.pop(0)
 
 _SERIES = 'series'
@@ -107,14 +108,14 @@ def unmerge_platform_patches(platform_patches_dir):
         return False
     orig_series = (platform_patches_dir / _SERIES_ORIG).read_text(encoding=ENCODING).splitlines()
     # patch path -> list of lines after patch path and before next patch path
-    path_comments = dict()
+    path_comments = {}
     # patch path -> inline comment for patch
-    path_inline_comments = dict()
+    path_inline_comments = {}
     previous_path = None
     for partial_path in orig_series:
         if not partial_path or partial_path.startswith('#'):
             if partial_path not in path_comments:
-                path_comments[previous_path] = list()
+                path_comments[previous_path] = []
             path_comments[previous_path].append(partial_path)
         else:
             path_parts = partial_path.split(' #', maxsplit=1)

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -24,7 +24,7 @@ For new flags, first add a constant to `third_party/ungoogled/ungoogled_switches
 
 ## Workflow of updating to a new Chromium version
 
-Tested on Debian 10 (buster). Exact instructions should work on any other Linux or macOS system with the proper dependencies.
+Tested on Debian 12 (bookworm). Exact instructions should work on any other Linux or macOS system with the proper dependencies.
 
 To gain a deeper understanding of this updating process, have a read through [docs/design.md](design.md).
 
@@ -33,7 +33,7 @@ To gain a deeper understanding of this updating process, have a read through [do
 * [`quilt`](http://savannah.nongnu.org/projects/quilt)
     * This is available in most (if not all) Linux distributions, and also Homebrew on macOS.
     * This utility facilitates most of the updating process, so it is important to learn how to use this. The manpage for quilt (as of early 2017) lacks an example of a workflow. There are multiple guides online, but [this guide from Debian](https://wiki.debian.org/UsingQuilt) and [the referenced guide on that page](https://raphaelhertzog.com/2012/08/08/how-to-use-quilt-to-manage-patches-in-debian-packages/) are the ones referenced in developing the current workflow.
-* Python 3.9 or newer
+* Python 3.10 or newer
     * `httplib2` and `six` are also required if you wish to utilize a source clone instead of the source tarball.
 
 ### Downloading the source code

--- a/utils/_common.py
+++ b/utils/_common.py
@@ -36,6 +36,7 @@ class ExtractorEnum: #pylint: disable=too-few-public-methods
 
 class SetLogLevel(argparse.Action): #pylint: disable=too-few-public-methods
     """Sets logging level based on command line arguments it receives"""
+
     def __init__(self, option_strings, dest, nargs=None, **kwargs):
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 

--- a/utils/downloads.py
+++ b/utils/downloads.py
@@ -25,6 +25,7 @@ from _extraction import extract_tar_file, extract_with_7z, extract_with_winrar
 
 sys.path.insert(0, str(Path(__file__).parent / 'third_party'))
 import schema #pylint: disable=wrong-import-position, wrong-import-order
+
 sys.path.pop(0)
 
 # Constants
@@ -74,6 +75,7 @@ class DownloadInfo: #pylint: disable=too-few-public-methods
     })
 
     class _DownloadsProperties: #pylint: disable=too-few-public-methods
+
         def __init__(self, section_dict, passthrough_properties, hashes):
             self._section_dict = section_dict
             self._passthrough_properties = passthrough_properties
@@ -97,7 +99,7 @@ class DownloadInfo: #pylint: disable=too-few-public-methods
                             value = value.split(DownloadInfo.hash_url_delimiter)
                         hashes_dict[hash_name] = value
                 return hashes_dict
-            raise AttributeError('"{}" has no attribute "{}"'.format(type(self).__name__, name))
+            raise AttributeError(f'"{type(self).__name__}" has no attribute "{name}"')
 
     def _parse_data(self, path):
         """
@@ -105,6 +107,7 @@ class DownloadInfo: #pylint: disable=too-few-public-methods
 
         Raises schema.SchemaError if validation fails
         """
+
         def _section_generator(data):
             for section in data:
                 if section == configparser.DEFAULTSECT:
@@ -157,11 +160,12 @@ class DownloadInfo: #pylint: disable=too-few-public-methods
             return
         for name in section_names:
             if name not in self:
-                raise KeyError('"{}" has no section "{}"'.format(type(self).__name__, name))
+                raise KeyError(f'"{type(self).__name__}" has no section "{name}"')
 
 
 class _UrlRetrieveReportHook: #pylint: disable=too-few-public-methods
     """Hook for urllib.request.urlretrieve to log progress information to console"""
+
     def __init__(self):
         self._max_len_printed = 0
         self._last_percentage = None
@@ -181,10 +185,10 @@ class _UrlRetrieveReportHook: #pylint: disable=too-few-public-methods
                 return
             self._last_percentage = percentage
             print('\r' + ' ' * self._max_len_printed, end='')
-            status_line = 'Progress: {:.1%} of {:,d} B'.format(percentage, total_size)
+            status_line = f'Progress: {percentage:.1%} of {total_size:,d} B'
         else:
             downloaded_estimate = block_count * block_size
-            status_line = 'Progress: {:,d} B of unknown size'.format(downloaded_estimate)
+            status_line = f'Progress: {downloaded_estimate:,d} B of unknown size'
         self._max_len_printed = len(status_line)
         print('\r' + status_line, end='')
 
@@ -259,7 +263,7 @@ def _get_hash_pairs(download_properties, cache_dir):
             if hash_processor == 'chromium':
                 yield from _chromium_hashes_generator(cache_dir / hash_filename)
             else:
-                raise ValueError('Unknown hash_url processor: %s' % hash_processor)
+                raise ValueError(f'Unknown hash_url processor: {hash_processor}')
         else:
             yield entry_type, entry_value
 

--- a/utils/filescfg.py
+++ b/utils/filescfg.py
@@ -57,10 +57,10 @@ def _get_archive_writer(output_path, timestamp=None):
     timestamp is a file timestamp to use for all files, if set.
     """
     if not output_path.suffixes:
-        raise ValueError('Output name has no suffix: %s' % output_path.name)
+        raise ValueError(f'Output name has no suffix: {output_path.name}')
     if output_path.suffixes[-1].lower() == '.zip':
         archive_root = Path(output_path.stem)
-        output_archive = zipfile.ZipFile(str(output_path), 'w', zipfile.ZIP_DEFLATED)
+        output_archive = zipfile.ZipFile(str(output_path), 'w', zipfile.ZIP_DEFLATED) # pylint: disable=consider-using-with
         zip_date_time = None
         if timestamp:
             zip_date_time = datetime.datetime.fromtimestamp(timestamp).timetuple()[:6]
@@ -83,17 +83,18 @@ def _get_archive_writer(output_path, timestamp=None):
                 zip_write(str(in_path), str(arc_path))
     elif '.tar' in output_path.name.lower():
         if len(output_path.suffixes) >= 2 and output_path.suffixes[-2].lower() == '.tar':
-            tar_mode = 'w:%s' % output_path.suffixes[-1][1:]
+            tar_mode = f'w:{output_path.suffixes[-1][1:]}'
             archive_root = Path(output_path.with_suffix('').stem)
         elif output_path.suffixes[-1].lower() == '.tar':
             tar_mode = 'w'
             archive_root = Path(output_path.stem)
         else:
-            raise ValueError('Could not detect tar format for output: %s' % output_path.name)
+            raise ValueError(f'Could not detect tar format for output: {output_path.name}')
         if timestamp:
 
             class TarInfoFixedTimestamp(tarfile.TarInfo):
                 """TarInfo class with predefined constant mtime"""
+
                 @property
                 def mtime(self):
                     """Return predefined timestamp"""
@@ -106,10 +107,13 @@ def _get_archive_writer(output_path, timestamp=None):
             tarinfo_class = TarInfoFixedTimestamp
         else:
             tarinfo_class = tarfile.TarInfo
-        output_archive = tarfile.open(str(output_path), tar_mode, tarinfo=tarinfo_class)
-        add_func = lambda in_path, arc_path: output_archive.add(str(in_path), str(arc_path))
+        output_archive = tarfile.open(str(output_path), tar_mode, tarinfo=tarinfo_class) # pylint: disable=consider-using-with
+
+        def add_func(in_path, arc_path):
+            """Add files to tar archive"""
+            output_archive.add(str(in_path), str(arc_path))
     else:
-        raise ValueError('Unknown archive extension with name: %s' % output_path.name)
+        raise ValueError(f'Unknown archive extension with name: {output_path.name}')
     return output_archive, add_func, archive_root
 
 
@@ -147,7 +151,7 @@ def _files_generator_by_args(args):
 
 def _list_callback(args):
     """List files needed to run Chromium."""
-    sys.stdout.writelines('%s\n' % x for x in _files_generator_by_args(args))
+    sys.stdout.writelines(f'{x}\n' for x in _files_generator_by_args(args))
 
 
 def _archive_callback(args):

--- a/utils/patches.py
+++ b/utils/patches.py
@@ -60,7 +60,7 @@ def find_and_check_patch(patch_bin_path=None):
         raise ValueError('Could not find patch from PATCH_BIN env var or "which patch"')
 
     if not patch_bin_path.exists():
-        raise ValueError('Could not find the patch binary: {}'.format(patch_bin_path))
+        raise ValueError(f'Could not find the patch binary: {patch_bin_path}')
 
     # Ensure patch actually runs
     cmd = [str(patch_bin_path), '--version']
@@ -73,7 +73,7 @@ def find_and_check_patch(patch_bin_path=None):
         get_logger().error('"%s" returned non-zero exit code', ' '.join(cmd))
         get_logger().error('stdout:\n%s', result.stdout)
         get_logger().error('stderr:\n%s', result.stderr)
-        raise RuntimeError('Got non-zero exit code running "{}"'.format(' '.join(cmd)))
+        raise RuntimeError(f"Got non-zero exit code running \"{' '.join(cmd)}\"")
 
     return patch_bin_path
 
@@ -167,18 +167,16 @@ def merge_patches(source_iter, destination, prepend=False):
         if prepend:
             if not (destination / 'series').exists():
                 raise FileNotFoundError(
-                    'Could not find series file in existing destination: {}'.format(destination /
-                                                                                    'series'))
+                    f"Could not find series file in existing destination: {destination / 'series'}")
             known_paths.update(generate_patches_from_series(destination))
         else:
-            raise FileExistsError('destination already exists: {}'.format(destination))
+            raise FileExistsError(f'destination already exists: {destination}')
     for source_dir in source_iter:
         patch_paths = tuple(generate_patches_from_series(source_dir))
         patch_intersection = known_paths.intersection(patch_paths)
         if patch_intersection:
-            raise FileExistsError(
-                'Patches from {} have conflicting paths with other sources: {}'.format(
-                    source_dir, patch_intersection))
+            raise FileExistsError(f'Patches from {source_dir} have conflicting paths '
+                                  f'with other sources: {patch_intersection}')
         series.extend(patch_paths)
         _copy_files(patch_paths, source_dir, destination)
     if prepend and (destination / 'series').exists():


### PR DESCRIPTION
This PR updates the Cirrus configs to use an image with python 3.10 so it is able to run depot_tools again.  This also updates our scripts for the image's new version of pylint.

Pylint removed `bad-continuation` so occurrences of that option have been removed.  It also required changes to spacing, using f-strings instead of format, using brackets and braces instead of empty dicts and lists, explicitly setting encoding, and using more specific exceptions.  There were a few lines that I've disabled `consider-using-with` since it would require more work to adjust and might be better for a future overhaul.  
