### PR TITLE
don't domain-substitute licenses, add UGC license to credits

### DIFF
--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -114,6 +114,8 @@ DOMAIN_EXCLUDE_PREFIXES = [
     'third_party/blink/renderer/core/dom/document.cc',
     # Exclusion to allow download of sysroots
     'build/linux/sysroot_scripts/sysroots.json',
+    # Licenses and credits
+    'tools/licenses/licenses.py',
 ]
 
 # pylint: enable=line-too-long
@@ -243,6 +245,10 @@ def should_domain_substitute(path, relative_path, search_regex, used_dep_set, us
             for exclude_prefix in DOMAIN_EXCLUDE_PREFIXES:
                 if relative_path_posix.startswith(exclude_prefix):
                     used_dep_set.add(exclude_prefix)
+                    return False
+            # Skip LICENSE.* files so that they remain untouched.
+            for license_path in ['license', 'license.txt', 'license.html']:
+                if relative_path_posix.endswith('/' + license_path):
                     return False
             return _check_regex_match(path, search_regex)
     return False

--- a/domain_substitution.list
+++ b/domain_substitution.list
@@ -6774,7 +6774,6 @@ third_party/catapult/third_party/gsutil/third_party/httplib2/python2/httplib2/__
 third_party/catapult/third_party/gsutil/third_party/httplib2/python3/httplib2/__init__.py
 third_party/catapult/third_party/gsutil/third_party/httplib2/tests/_TODO_legacy/python2/httplib2test_appengine.py
 third_party/catapult/third_party/gsutil/third_party/httplib2/tests/test_proxy.py
-third_party/catapult/third_party/gsutil/third_party/pyasn1-modules/LICENSE.txt
 third_party/catapult/third_party/gsutil/third_party/pyasn1-modules/pyasn1_modules/pem.py
 third_party/catapult/third_party/gsutil/third_party/pyasn1-modules/pyasn1_modules/rfc1155.py
 third_party/catapult/third_party/gsutil/third_party/pyasn1-modules/pyasn1_modules/rfc1157.py
@@ -7002,7 +7001,6 @@ third_party/catapult/third_party/polymer/components/webcomponentsjs/ShadowDOM.js
 third_party/catapult/third_party/polymer/components/webcomponentsjs/ShadowDOM.min.js
 third_party/catapult/third_party/polymer/components/webcomponentsjs/webcomponents.js
 third_party/catapult/third_party/polymer/components/webcomponentsjs/webcomponents.min.js
-third_party/catapult/third_party/pyasn1/LICENSE.txt
 third_party/catapult/third_party/pyasn1/pyasn1/codec/ber/decoder.py
 third_party/catapult/third_party/pyasn1/pyasn1/codec/ber/encoder.py
 third_party/catapult/third_party/pyasn1/pyasn1/codec/ber/eoo.py
@@ -7031,7 +7029,6 @@ third_party/catapult/third_party/pyasn1/pyasn1/type/tag.py
 third_party/catapult/third_party/pyasn1/pyasn1/type/tagmap.py
 third_party/catapult/third_party/pyasn1/pyasn1/type/univ.py
 third_party/catapult/third_party/pyasn1/pyasn1/type/useful.py
-third_party/catapult/third_party/pyasn1_modules/LICENSE.txt
 third_party/catapult/third_party/pyasn1_modules/pyasn1_modules/pem.py
 third_party/catapult/third_party/pyasn1_modules/pyasn1_modules/rfc1155.py
 third_party/catapult/third_party/pyasn1_modules/pyasn1_modules/rfc1157.py
@@ -14262,7 +14259,6 @@ third_party/swiftshader/third_party/llvm-subzero/include/llvm/Support/CommandLin
 third_party/swiftshader/third_party/llvm-subzero/include/llvm/Support/Compiler.h
 third_party/swiftshader/third_party/marl/include/marl/trace.h
 third_party/swiftshader/third_party/marl/src/trace.cpp
-third_party/swiftshader/third_party/subzero/LICENSE.TXT
 third_party/swiftshader/third_party/subzero/Makefile
 third_party/swiftshader/third_party/subzero/bloat/webtreemap.js
 third_party/swiftshader/third_party/subzero/pnacl-llvm/README.txt
@@ -15046,7 +15042,6 @@ tools/json_schema_compiler/preview.py
 tools/json_schema_compiler/test/tabs.json
 tools/json_schema_compiler/test/windows.json
 tools/json_to_struct/PRESUBMIT.py
-tools/licenses/licenses.py
 tools/licenses/licenses_test.py
 tools/linux/PRESUBMIT.py
 tools/mac/download_symbols.py
@@ -15807,7 +15802,6 @@ url/gurl_unittest.cc
 url/ipc/url_param_traits_unittest.cc
 url/mojom/url_gurl_mojom_traits_unittest.cc
 url/origin_unittest.cc
-url/third_party/mozilla/LICENSE.txt
 url/third_party/mozilla/url_parse.cc
 url/third_party/mozilla/url_parse.h
 url/url_canon_relative.cc

--- a/patches/extra/ungoogled-chromium/add-credits.patch
+++ b/patches/extra/ungoogled-chromium/add-credits.patch
@@ -1,0 +1,71 @@
+--- a/components/webui/about/resources/about_credits_reciprocal.tmpl
++++ b/components/webui/about/resources/about_credits_reciprocal.tmpl
+@@ -1,4 +1,4 @@
+ <div class="open-sourced">
+-    {{opensource_project}} software is made available as source code
+-    <a href="{{opensource_link}}">here</a>.
++    {{opensource_project}} source code is available in
++    the <a href="{{opensource_link}}">repository</a>.
+ </div>
+--- a/tools/licenses/licenses.py
++++ b/tools/licenses/licenses.py
+@@ -1015,6 +1015,16 @@ def GenerateCredits(file_template_file,
+   entries.append(
+       MetadataToTemplateEntry(chromium_license_metadata, entry_template))
+ 
++  ugc_license_metadata = {
++      'Name': 'ungoogled-chromium',
++      'URL': 'https://github.com/ungoogled-software/ungoogled-chromium',
++      'Shipped': 'yes',
++      'License File': [os.path.join(_REPOSITORY_ROOT, 'third_party', 'ungoogled-chromium', 'LICENSE')],
++  }
++
++  entries.append(
++      MetadataToTemplateEntry(ugc_license_metadata, entry_template))
++
+   entries_by_name = {}
+   for path in third_party_dirs:
+     try:
+@@ -1059,8 +1069,8 @@ def GenerateCredits(file_template_file,
+   reciprocal_template = codecs.open(reciprocal_template_file,
+                                     encoding='utf-8').read()
+   reciprocal_contents = EvaluateTemplate(reciprocal_template, {
+-      'opensource_project': 'Chromium',
+-      'opensource_link': 'https://source.chromium.org/chromium'
++      'opensource_project': 'ungoogled-chromium',
++      'opensource_link': 'https://github.com/ungoogled-software/ungoogled-chromium'
+   },
+                                          escape=False)
+ 
+--- /dev/null
++++ b/third_party/ungoogled-chromium/LICENSE
+@@ -0,0 +1,29 @@
++BSD 3-Clause License
++
++Copyright (c) 2015-2025, The ungoogled-chromium Authors
++All rights reserved.
++
++Redistribution and use in source and binary forms, with or without
++modification, are permitted provided that the following conditions are met:
++
++1. Redistributions of source code must retain the above copyright notice, this
++   list of conditions and the following disclaimer.
++
++2. Redistributions in binary form must reproduce the above copyright notice,
++   this list of conditions and the following disclaimer in the documentation
++   and/or other materials provided with the distribution.
++
++3. Neither the name of the copyright holder nor the names of its
++   contributors may be used to endorse or promote products derived from
++   this software without specific prior written permission.
++
++THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
++DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
++FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
++DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
++SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
++CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
++OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
++OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/patches/series
+++ b/patches/series
@@ -111,3 +111,4 @@ extra/ungoogled-chromium/remove-pac-size-limit.patch
 extra/ungoogled-chromium/enable-certificate-transparency-and-add-flag.patch
 extra/ungoogled-chromium/add-flag-to-spoof-webgl-renderer-info.patch
 extra/ungoogled-chromium/add-flag-to-increase-incognito-storage-quota.patch
+extra/ungoogled-chromium/add-credits.patch


### PR DESCRIPTION
Related: #3402

- Excludes all LICENSE files as well as the script from domain substitution, so they are preserved in the original form on the chrome://credits page.

- Adds the `ungoogled-chromium` license to the credits page. Without this, ungoogled-chromium binaries might be breaking the `Redistributions in binary form must reproduce the above copyright notice` clause of the license (maybe, maybe not? I am not a lawyer, regardless, I don't think it would be a terrible idea to include it on the credits page).

I generated a preview of the credits page after this patch for convenience here: https://crcr-2kn.pages.dev/ (with patched stylesheet imports, so they still work).
<details>

<summary>Diff of the credits page before and after this patch</summary>

```diff
--- before.html	2025-07-25 12:16:33.588638714 +0000
+++ after.html	2025-07-25 12:33:38.894307219 +0000
@@ -15,8 +15,8 @@
 <input type="checkbox" hidden>
 </label>
 <div class="open-sourced">
-    Chromium software is made available as source code
-    <a href="https://source.ch40m1um.qjz9zk/chromium">here</a>.
+    The patches which make up ungoogled-chromium are
+    available in the <a href="https://github.com/ungoogled-software/ungoogled-chromium">repository</a>.
 </div>
 
 <div style="clear:both; overflow:auto;"><!-- Chromium <3s the following projects -->
@@ -1709,7 +1709,7 @@
 
 <div class="product">
 <span class="title">Almost Native Graphics Layer Engine</span>
-<span class="homepage"><a href="https://chromium.9oo91esource.qjz9zk/angle/angle/">homepage</a></span>
+<span class="homepage"><a href="https://chromium.googlesource.com/angle/angle/">homepage</a></span>
 <label class="show" tabindex="0">
 <input type="checkbox" hidden>
 </label>
@@ -20848,7 +20848,7 @@
 
 <div class="product">
 <span class="title">BoringSSL</span>
-<span class="homepage"><a href="https://boringssl.9oo91esource.qjz9zk/boringssl/">homepage</a></span>
+<span class="homepage"><a href="https://boringssl.googlesource.com/boringssl">homepage</a></span>
 <label class="show" tabindex="0">
 <input type="checkbox" hidden>
 </label>
@@ -21097,7 +21097,7 @@
 
 <div class="product">
 <span class="title">BoringSSL</span>
-<span class="homepage"><a href="https://boringssl.googlesource.com/boringssl">homepage</a></span>
+<span class="homepage"><a href="https://boringssl.googlesource.com/boringssl/">homepage</a></span>
 <label class="show" tabindex="0">
 <input type="checkbox" hidden>
 </label>
@@ -23567,7 +23567,7 @@
 
 <div class="product">
 <span class="title">Chromium OS system API</span>
-<span class="homepage"><a href="https://www.ch40m1um.qjz9zk/chromium-os">homepage</a></span>
+<span class="homepage"><a href="https://www.chromium.org/chromium-os">homepage</a></span>
 <label class="show" tabindex="0">
 <input type="checkbox" hidden>
 </label>
@@ -107866,7 +107866,7 @@
 
 <div class="product">
 <span class="title">ipcz</span>
-<span class="homepage"><a href="https://chromium.9oo91esource.qjz9zk/chromium/src/third_party/ipcz">homepage</a></span>
+<span class="homepage"><a href="https://chromium.googlesource.com/chromium/src/third_party/ipcz">homepage</a></span>
 <label class="show" tabindex="0">
 <input type="checkbox" hidden>
 </label>
@@ -118834,7 +118834,7 @@
 
 <div class="product">
 <span class="title">linux-syscall-support</span>
-<span class="homepage"><a href="https://chromium.9oo91esource.qjz9zk/linux-syscall-support/">homepage</a></span>
+<span class="homepage"><a href="https://chromium.googlesource.com/linux-syscall-support/">homepage</a></span>
 <label class="show" tabindex="0">
 <input type="checkbox" hidden>
 </label>
@@ -128594,7 +128594,7 @@
 
 <div class="product">
 <span class="title">PDFium</span>
-<span class="homepage"><a href="https://pdfium.9oo91esource.qjz9zk/pdfium/">homepage</a></span>
+<span class="homepage"><a href="https://pdfium.googlesource.com/pdfium/">homepage</a></span>
 <label class="show" tabindex="0">
 <input type="checkbox" hidden>
 </label>
@@ -233813,7 +233813,7 @@
 <input type="checkbox" hidden>
 </label>
 <div class="license">
-<pre>Copyright (c) 2005-2019, Ilya Etingof &lt;etingof@9ma1l.qjz9zk&gt;
+<pre>Copyright (c) 2005-2019, Ilya Etingof &lt;etingof@gmail.com&gt;
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -255185,7 +255185,7 @@
 
 <div class="product">
 <span class="title">SwiftShader</span>
-<span class="homepage"><a href="https://swiftshader.9oo91esource.qjz9zk/SwiftShader">homepage</a></span>
+<span class="homepage"><a href="https://swiftshader.googlesource.com/SwiftShader">homepage</a></span>
 <label class="show" tabindex="0">
 <input type="checkbox" hidden>
 </label>
@@ -256718,7 +256718,7 @@
 
 <div class="product">
 <span class="title">The Chromium Project</span>
-<span class="homepage"><a href="https://www.ch40m1um.qjz9zk">homepage</a></span>
+<span class="homepage"><a href="https://www.chromium.org">homepage</a></span>
 <label class="show" tabindex="0">
 <input type="checkbox" hidden>
 </label>
@@ -259044,6 +259044,46 @@
 </div>
 
 <div class="product">
+<span class="title">ungoogled-chromium</span>
+<span class="homepage"><a href="https://github.com/ungoogled-software/ungoogled-chromium">homepage</a></span>
+<label class="show" tabindex="0">
+<input type="checkbox" hidden>
+</label>
+<div class="license">
+<pre>BSD 3-Clause License
+
+Copyright (c) 2015-2025, The ungoogled-chromium Authors
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS &quot;AS IS&quot;
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+</pre>
+</div>
+</div>
+
+<div class="product">
 <span class="title">Unicode Common Locale Data Repository</span>
 <span class="homepage"><a href="http://cldr.unicode.org/index/downloads">homepage</a></span>
 <label class="show" tabindex="0">
@@ -259443,14 +259483,14 @@
 The contents of this file are subject to the Mozilla Public License Version
 1.1 (the &quot;License&quot;); you may not use this file except in compliance with
 the License. You may obtain a copy of the License at
-http://www.m0z111a.qjz9zk/MPL/
+http://www.mozilla.org/MPL/
 
 Software distributed under the License is distributed on an &quot;AS IS&quot; basis,
 WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
 for the specific language governing rights and limitations under the
 License.
 
-The Original Code is m0z111a.qjz9zk code.
+The Original Code is mozilla.org code.
 
 The Initial Developer of the Original Code is
 Netscape Communications Corporation.
```
</details>

One thing I was uncertain about is how to introduce the UGC license into the Chromium source tree. This patch duplicates it - it's once in the LICENSE file, and now in this patch, which is not ideal. I considered copying it from the root repo in some script, but couldn't find any appropriate script to put it that would result in it being included 100% of the time. If anyone has better ideas, I am open to them.