### PR TITLE
Preserve Google WebAuthn AppID validation

### DIFF
--- a/devutils/update_lists.py
+++ b/devutils/update_lists.py
@@ -109,6 +109,11 @@ PRUNING_EXCLUDE_PATTERNS = [
 # Paths to exclude by prefixes of the POSIX representation for domain substitution
 DOMAIN_EXCLUDE_PREFIXES = [
     'components/test/',
+    # Preserve local validation and test vectors for legacy Google WebAuthn AppIDs.
+    # The checker compares these AppID URLs locally and does not fetch them.
+    'content/browser/webauth/authenticator_impl_unittest.cc',
+    'content/browser/webauth/webauth_request_security_checker_impl.cc',
+    'content/browser/webauth/webauth_request_security_checker_impl.h',
     'net/http/transport_security_state_static.json',
     'net/http/transport_security_state_static_pins.json',
     # Exclusions for Visual Studio Project generation with GN (PR #445)

--- a/domain_substitution.list
+++ b/domain_substitution.list
@@ -4515,11 +4515,8 @@ content/browser/web_contents/web_contents_view_aura_unittest.cc
 content/browser/web_contents/web_contents_view_mac_unittest.mm
 content/browser/web_contents/web_drag_dest_mac_unittest.mm
 content/browser/webauth/authenticator_common_impl.cc
-content/browser/webauth/authenticator_impl_unittest.cc
 content/browser/webauth/authenticator_mojom_traits_unittest.cc
 content/browser/webauth/authenticator_test_base.h
-content/browser/webauth/webauth_request_security_checker_impl.cc
-content/browser/webauth/webauth_request_security_checker_impl.h
 content/browser/webauth/webauth_request_security_checker_impl_unittest.cc
 content/browser/webid/delegation/jwt_signer_unittest.cc
 content/browser/webid/idp_network_request_manager_unittest.cc


### PR DESCRIPTION
Fixes #3913.

Domain substitution rewrites the Google-domain check and both gstatic AppID constants in Chromiums WebAuthn security checker. That makes the built-in Google compatibility rule impossible to match, so current Google passkey creation fails with SecurityError before an attached WebAuthn proxy can receive the request.

Exclude only the checker implementation and header from substitution. Their Google strings are local validation constants, not service endpoints used for background requests.

Validation:
- reproduced explicit appidExclude rejection on an accounts.google.com page in an ungoogled-based Chromium 146 build
- verified the equivalent googleLegacyAppidSupport request reaches chrome.webAuthenticationProxy
- git diff --check
- directly executed utils.tests.test_domain_substitution.test_update_timestamp with PYTHONPATH=.:utils

A full Chromium build is intentionally left to project CI.