### PR TITLE
Add flag to --force-prefers-reduced-motion and --force-prefers-no-reduced-motion

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -90,6 +90,7 @@ Chromium contains switches that do no have corresponding entries in `chrome://fl
   `--disable-webgl` | Disable all versions of WebGL.
   `--enable-low-end-device-mode` | Force low-end device mode when set.
   `--force-dark-mode` | Forces dark mode in UI for platforms that support it.
+  `--force-prefers-reduced-motion` / `--force-prefers-no-reduced-motion` |  The flag "Force reduced motion" sets one of these two switches. Forces whether the user desires reduced motion, regardless of system settings.
   `--no-default-browser-check` | Disables the default browser check.
   `--no-pings` | Don't send hyperlink auditing pings.
   `--webrtc-ip-handling-policy` | Restrict which IP addresses and interfaces WebRTC uses.

--- a/patches/extra/ungoogled-chromium/add-flags-for-existing-switches.patch
+++ b/patches/extra/ungoogled-chromium/add-flags-for-existing-switches.patch
@@ -81,3 +81,30 @@
 +     "Restrict which IP addresses and interfaces WebRTC uses. Chromium feature, ungoogled-chromium flag.",
 +     kOsAll, MULTI_VALUE_TYPE(kWebRTCIPPolicy)},
 +#endif  // CHROME_BROWSER_EXISTING_SWITCH_FLAG_ENTRIES_H_
+--- a/chrome/browser/ungoogled_flag_choices.h
++++ b/chrome/browser/ungoogled_flag_choices.h
+@@ -79,4 +79,13 @@ const FeatureEntry::Choice kTabHoverCard
+      "tab-hover-cards",
+      "tooltip"},
+ };
++const FeatureEntry::Choice kForceReducedMotion[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Force reduced motion",
++     "force-prefers-reduced-motion",
++     ""},
++    {"Force no reduced motion",
++     "force-prefers-no-reduced-motion",
++     ""},
++};
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_CHOICES_H_
+--- a/chrome/browser/ungoogled_flag_entries.h
++++ b/chrome/browser/ungoogled_flag_entries.h
+@@ -120,4 +120,8 @@
+      "Minimal Referrers",
+      "Removes all cross-origin referrers and strips same-origin referrers down to the origin. Has lower precedence than remove-cross-origin-referrers. ungoogled-chromium flag.",
+      kOsAll, FEATURE_VALUE_TYPE(network::features::kMinimalReferrers)},
++    {"force-reduced-motion",
++     "Force reduced motion",
++     "Forces whether the user desires reduced motion, regardless of system settings. ungoogled-chromium flag.",
++     kOsAll, MULTI_VALUE_TYPE(kForceReducedMotion)},
+ #endif  // CHROME_BROWSER_UNGOOGLED_FLAG_ENTRIES_H_


### PR DESCRIPTION
Add flag "Force reduced motion" using existing switches like Firefox's "ui.prefersReducedMotion". It has three options: Default, Force reduced motion, Force no reduced motion.
