### PR TITLE
Add flag to force reduced motion or no reduced motion

### DIFF
--- a/docs/flags.md
+++ b/docs/flags.md
@@ -90,6 +90,7 @@ Chromium contains switches that do no have corresponding entries in `chrome://fl
   `--disable-webgl` | Disable all versions of WebGL.
   `--enable-low-end-device-mode` | Force low-end device mode when set.
   `--force-dark-mode` | Forces dark mode in UI for platforms that support it.
+  `--force-prefers-reduced-motion` / `--force-prefers-no-reduced-motion` |  The flag "Force reduced motion" sets one of these two switches. Forces whether the user desires reduced motion, regardless of system settings.
   `--no-default-browser-check` | Disables the default browser check.
   `--no-pings` | Don't send hyperlink auditing pings.
   `--webrtc-ip-handling-policy` | Restrict which IP addresses and interfaces WebRTC uses.

--- a/patches/extra/ungoogled-chromium/add-flags-for-existing-switches.patch
+++ b/patches/extra/ungoogled-chromium/add-flags-for-existing-switches.patch
@@ -15,13 +15,22 @@
  #include "build/chromeos_buildflags.h"
 --- /dev/null
 +++ b/chrome/browser/existing_switch_flag_choices.h
-@@ -0,0 +1,19 @@
+@@ -0,0 +1,28 @@
 +// Copyright (c) 2023 The ungoogled-chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#ifndef CHROME_BROWSER_EXISTING_SWITCH_FLAG_CHOICES_H_
 +#define CHROME_BROWSER_EXISTING_SWITCH_FLAG_CHOICES_H_
++const FeatureEntry::Choice kForceReducedMotion[] = {
++    {flags_ui::kGenericExperimentChoiceDefault, "", ""},
++    {"Force reduced motion",
++     "force-prefers-reduced-motion",
++     ""},
++    {"Force no reduced motion",
++     "force-prefers-no-reduced-motion",
++     ""},
++};
 +const FeatureEntry::Choice kWebRTCIPPolicy[] = {
 +    {"Disable non proxied udp", "", ""},
 +    {"Default",
@@ -37,7 +46,7 @@
 +#endif  // CHROME_BROWSER_EXISTING_SWITCH_FLAG_CHOICES_H_
 --- /dev/null
 +++ b/chrome/browser/existing_switch_flag_entries.h
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,47 @@
 +// Copyright (c) 2023 The ungoogled-chromium Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -60,6 +69,10 @@
 +     "Force Dark Mode",
 +     "Forces dark mode in UI for platforms that support it. Chromium feature, ungoogled-chromium flag.",
 +     kOsAll, SINGLE_VALUE_TYPE("force-dark-mode")},
++    {"force-reduced-motion",
++     "Force reduced motion",
++     "Forces whether the user desires reduced motion, regardless of system settings. Chromium feature, ungoogled-chromium flag.",
++     kOsAll, MULTI_VALUE_TYPE(kForceReducedMotion)},
 +    {"incognito",
 +     "Start in incognito",
 +     "Start in Incognito. Chromium feature, ungoogled-chromium flag.",


### PR DESCRIPTION
Add flag "Force reduced motion" using existing switches, like Firefox's "ui.prefersReducedMotion". It has three options: Default, Force reduced motion, Force no reduced motion. Closes #3786 