### PR TITLE
properly set omnibox-autocomplete-filtering flags

### DIFF
--- a/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
+++ b/patches/extra/ungoogled-chromium/add-flag-for-omnibox-autocomplete-filtering.patch
@@ -47,7 +47,7 @@
    config_.provider_types &= ~OmniboxFieldTrial::GetDisabledProviderTypes();
 +  if (base::CommandLine::ForCurrentProcess()->HasSwitch("omnibox-autocomplete-filtering")) {
 +    const std::string flag_value = base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII("omnibox-autocomplete-filtering");
-+    config_.provider_types &= AutocompleteProvider::TYPE_KEYWORD | AutocompleteProvider::TYPE_SEARCH |
++    config_.provider_types = AutocompleteProvider::TYPE_KEYWORD | AutocompleteProvider::TYPE_SEARCH |
 +        AutocompleteProvider::TYPE_HISTORY_URL | AutocompleteProvider::TYPE_BOOKMARK | AutocompleteProvider::TYPE_BUILTIN;
 +    if (!flag_value.contains("bookmarks"))
 +      config_.provider_types &= ~AutocompleteProvider::TYPE_BOOKMARK;


### PR DESCRIPTION
TYPE_KEYWORD, TYPE_SEARCH, TYPE_HISTORY_URL, TYPE_BOOKMARK, TYPE_BUILTIN flags are set using bitwise `&`, this worked because these flags are also set in upstream code

use `=` instead of `&=` to assign these flags and filter out other upstream flags 

remove unnecessary bitwise `&` operation to make code clearer and set the required flags without depending on them being set in upstream code too
